### PR TITLE
Use startswith() to determine if method is getter

### DIFF
--- a/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
+++ b/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
@@ -97,8 +97,8 @@ public class ReflectionUtil {
     }
 
     public static boolean isGetter(Method m) {
-        return (m.getName().substring(0,3).equals("get")  ||
-                m.getName().substring(0,2).equals("is") ) &&
+        return (m.getName().startsWith("get") ||
+                m.getName().startsWith("is")) &&
                 m.getParameterTypes().length == 0;
     }
 


### PR DESCRIPTION
The function `isGetter()` checks if a method name begins with "get" or
"is". Previously, the code used `.substring(0,3)`, which throws an error
if the method name is fewer than 3 characters. `startswith()` won't
throw an error in that case and will instead return false.