### PR TITLE
For WildcardType, use Types of upper bounds (i.e. erase wildcard)

### DIFF
--- a/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
+++ b/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
@@ -139,7 +139,19 @@ public class ReflectionUtil {
 
             if (t instanceof Class || t instanceof ParameterizedType) {
                 result.add(t);
+            } else if (t instanceof WildcardType) {
+                // If the wildcard type has an explicit upper bound (i.e. not Object), we use that
+                WildcardType wildcardType = (WildcardType) t;
+                if (wildcardType.getLowerBounds().length == 0) {
+                    for (Type type : wildcardType.getUpperBounds()) {
+                        if (type instanceof Class && ((Class<?>) type).equals(Object.class)) {
+                            continue;
+                        }
+                        result.add(type);
+                    }
+                }
             }
+
         }
 
         return Collections.unmodifiableList(result);

--- a/javers-core/src/test/groovy/org/javers/core/metamodel/type/CollectionTypeTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/metamodel/type/CollectionTypeTest.groovy
@@ -17,6 +17,7 @@ class CollectionTypeTest extends Specification{
     class Dummy <T> {
         Set rawType
         Set<?> unboundedWildcardType
+        Set<? extends String> boundedWildcardType
         Set<T> genericType
         Set<String> parametrizedType
         Set<ThreadLocal<String>> nestedParametrizedType
@@ -48,6 +49,20 @@ class CollectionTypeTest extends Specification{
 
         then:
         cType.baseJavaType == new TypeToken<Set<String>>(){}.type
+        cType.genericType == true
+        cType.fullyParametrized == true
+        cType.itemType == String
+    }
+
+    def "should treat wildcards with an upper bound as the type of its upper bound" () {
+        given:
+        def genericWithArgument = getFieldFromClass(Dummy, "boundedWildcardType").genericType
+
+        when:
+        def cType = new ListType(genericWithArgument)
+
+        then:
+        cType.baseJavaType == new TypeToken<Set<? extends String>>(){}.type
         cType.genericType == true
         cType.fullyParametrized == true
         cType.itemType == String


### PR DESCRIPTION
If I try to use JaVers to compare classes with upper-bounded wildcard types, I get an exception with message like the following:

```
beaconJaversException: GENERIC_TYPE_NOT_PARAMETRIZED JaVers runtime error - 
expected actual Class argument in type 'java.util.Set<? extends Foo>'. 
JaVers is strongly-typed and needs to know actual Class of elements stored in your collections. 
```

with an instruction to:

```
Try at least <Object>. Wildcards (e.g. <?>), unbounded type parameters (e.g. <T>) and raw types (e.g. List) are not supported.
```

For reasons, we cannot easily alter our model to narrow to `Set<Foo>` or `Set<SpecificSubclassOfFoo>`, and anyway we would prefer not to let our choice of this (admittedly wonderful) tool drive such things.

The error actually does not say that bounded parameters are not supported, so this pull request - treating wildcards with an upper bound as having the type of the upper bound - seems consistent with it. Certainly the tests still pass, and the behaviour is as we would expect.

In addition (and perhaps this should be the subject of another pull request), a more general change to include unbounded types (which seems like it's the same as "Try at least <Object>") might be worth considering, though such a change would break your tests (but only the ones that expect the GENERIC_TYPE_NOT_PARAMETRIZED error).

We've only recently started using JaVers, and our usage may be fairly narrow, so it's quite possible we've missed some obvious reason why this is not a good idea, but would appreciate if you would consider it.