### PR TITLE
Commit date formatting in SimpleTextChangelog

### DIFF
--- a/javers-core/src/main/java/org/javers/core/changelog/SimpleTextChangeLog.java
+++ b/javers-core/src/main/java/org/javers/core/changelog/SimpleTextChangeLog.java
@@ -45,7 +45,7 @@ public class SimpleTextChangeLog extends AbstractTextChangeLog {
     @Override
     public void onCommit(CommitMetadata commitMetadata) {
         appendln("commit " + commitMetadata.getId() + ", author: " + commitMetadata.getAuthor() +
-                ", " + DEFAULT_DATE_FORMATTER.print(commitMetadata.getCommitDate()));
+                ", " + dateTimeFormatter.print(commitMetadata.getCommitDate()));
     }
 
     @Override


### PR DESCRIPTION
Pewnie najlepiej byłoby żeby przekazany dateTimeFormatter był wykorzystywany również do wypisywania zmian dotyczących dat. Natomiast ta wersja jest lepsza od stanu obecnego bo używa formattera przekazanego w konstruktorze przynajmniej do wypisania daty i czasu commita.