### PR TITLE
Fix of H2 repository test environment

### DIFF
--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2ETest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2ETest.groovy
@@ -1,15 +1,36 @@
 package org.javers.repository.sql
 
+import org.javers.core.model.SnapshotEntity
+import org.javers.repository.jql.QueryBuilder
+
 import java.sql.Connection
 import java.sql.DriverManager
 
 class H2SqlRepositoryE2ETest extends JaversSqlRepositoryE2ETest {
 
     Connection createConnection() {
-        DriverManager.getConnection( "jdbc:h2:mem:test" )//TRACE_LEVEL_SYSTEM_OUT=2")
+        DriverManager.getConnection( "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1" )
     }
 
     DialectName getDialect() {
         DialectName.H2
     }
+
+
+    def "should persist over 100 snapshots with proper sequence of primary keys"() {
+        given:
+        (150..1).each{
+            javers.commit("author", new SnapshotEntity(id: 1, intProperty: it))
+        }
+
+        when:
+        def query = QueryBuilder.byInstanceId(1, SnapshotEntity).limit(150).build()
+        def snapshots = javers.findSnapshots(query)
+        def intPropertyValues = snapshots.collect { it.getPropertyValue("intProperty") }
+
+        then:
+        intPropertyValues == 1..150
+    }
+
+
 }


### PR DESCRIPTION
After each test case connection to SQL database is closed.
DB_CLOSE_DELAY=-1 in database URL prevents inmemory H2 
database from closing (and losing all its content) after last
connection to database is closed.

It's important because of a way in which PolyJDBC handles primary
keys generation. PolyJDBC can generate more than one key from a 
single sequence value fetch. In consequence isolation between test 
cases is broken.