### PR TITLE
Issue #355 JaversAuditableRepositoryAspect does not properly handle thrown exceptions

### DIFF
--- a/javers-spring/src/main/java/org/javers/spring/auditable/aspect/JaversAuditableRepositoryAspect.java
+++ b/javers-spring/src/main/java/org/javers/spring/auditable/aspect/JaversAuditableRepositoryAspect.java
@@ -2,9 +2,7 @@ package org.javers.spring.auditable.aspect;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
-import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.javers.common.collections.Optional;
 import org.javers.core.Javers;
 import org.javers.spring.annotation.JaversSpringDataAuditable;
@@ -13,20 +11,21 @@ import org.javers.spring.auditable.AuthorProvider;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.lang.annotation.Annotation;
 
 /**
- * Creates three @After advices.
+ * Creates three @AfterReturning advices.
  * <br/><br/>
  *
- * Commits all arguments passed to methods with @JaversAuditable annotation.
+ * Commits all arguments passed to methods with @JaversAuditable annotation only if the method exits normally, e.g. no
+ * Throwable has been thrown. If the method is also annotated with @Transactional and the noRollbackFor or
+ * noRollbackForClassName are used, no commit will be done as the method still throws a Throwable. A manual
+ * {@link Javers#commit(String, Object)} can be used instead.
  * <br/><br/>
  *
  * For spring-data Repositories with @JaversSpringDataAuditable annotation: <br/>
  * - commits all arguments passed to save() methods,  <br/>
  * - commits delete of arguments passed to delete() methods.  <br/>
+ * - commits only when a method exits normally without a Throwable having been thrown.
  */
 @Aspect
 public class JaversAuditableRepositoryAspect {
@@ -51,38 +50,14 @@ public class JaversAuditableRepositoryAspect {
         javersCommitAdvice.commitMethodArguments(pjp);
     }
 
-    @AfterThrowing(value = "@annotation(org.javers.spring.annotation.JaversAuditable)", throwing = "ex")
-    public void commitAdvice(JoinPoint pjp, Throwable ex) {
-        //If we are supposed to still execute, despite the exception, do so
-        if( isStillExecute(pjp, ex) ) {
-            commitAdvice(pjp);
-        }
-    }
-
     @AfterReturning("execution(public * delete(..)) && this(org.springframework.data.repository.CrudRepository)")
     public void onDeleteExecuted(JoinPoint pjp)  {
         onVersionEvent(pjp, deleteHandler);
     }
 
-    @AfterThrowing(value = "execution(public * delete(..)) && this(org.springframework.data.repository.CrudRepository)", throwing = "ex")
-    public void onDeleteExecuted(JoinPoint pjp, Throwable ex)  {
-        //If we are supposed to still execute, despite the exception, do so
-        if( isStillExecute(pjp, ex) ) {
-            onDeleteExecuted(pjp);
-        }
-    }
-
     @AfterReturning("execution(public * save(..)) && this(org.springframework.data.repository.CrudRepository)")
     public void onSaveExecuted(JoinPoint pjp) {
         onVersionEvent(pjp, saveHandler);
-    }
-
-    @AfterThrowing(value = "execution(public * save(..)) && this(org.springframework.data.repository.CrudRepository)", throwing = "ex")
-    public void onSaveExecuted(JoinPoint pjp, Throwable ex) {
-        //If we are supposed to still execute, despite the exception, do so
-        if( isStillExecute(pjp, ex) ) {
-            onSaveExecuted(pjp);
-        }
     }
 
     private void onVersionEvent(JoinPoint pjp, AuditChangeHandler handler) {
@@ -118,57 +93,5 @@ public class JaversAuditableRepositoryAspect {
 
     private void applyVersionChange(RepositoryMetadata metadata, Object domainObject, AuditChangeHandler handler) {
         handler.handle(metadata, domainObject);
-    }
-
-    /**
-     * Returns TRUE if the {@link Throwable} matches against the current {@link JoinPoint}s method with Spring's @{@link Transactional}
-     * noRollbackFor or noRoolbackForClassName values.
-     *
-     * @param ex the {@link Throwable} which was thrown
-     * @param pjp the {@link JoinPoint} we are currently at
-     * @return TRUE if the advised method has @{@link Transactional} and will commit despite this @{@link Throwable}
-     */
-    protected boolean isStillExecute(JoinPoint pjp, Throwable ex) {
-        //Grab the current method signature we are operating on, and the Spring Transactional Annotation, if any
-        MethodSignature signature = (MethodSignature)pjp.getSignature();
-        Transactional transactionalAnnotation = signature.getMethod().getAnnotation(Transactional.class);
-
-        // If there is no Spring @Transactional annotation on the method, then we don't want to execute the normal
-        // versioning code
-        if( transactionalAnnotation == null ) {
-            return false;
-        }
-
-        boolean executeCommit = false;
-        Class<? extends Throwable> exceptionClass = ex.getClass();
-        //grab the @Transactional noRollbackFor classes
-        Class<? extends Throwable>[] noRollbackForClasses = transactionalAnnotation.noRollbackFor();
-        if( noRollbackForClasses != null && noRollbackForClasses.length > 0 ) {
-            for( Class<? extends Throwable> aClass : noRollbackForClasses ) {
-                //if the exception class matches a class to NOT rollback for, match and break
-                if( aClass.equals(exceptionClass) ) {
-                    executeCommit = true;
-                    break;
-                }
-            }
-        }
-
-        //if we didn't match on a noRollbackFor classes, we need to check the noRollbackForClassName
-        if( !executeCommit ) {
-            String[] noRollbackForClassNames = transactionalAnnotation.noRollbackForClassName();
-            String exceptionClassName = exceptionClass.getName();
-            for( String className : noRollbackForClassNames ) {
-                //if the exception class name (will be fully qualified class + package) ends with the specified class
-                //name, it'll either match the base class name, or the fully qualified class + package, whichever was
-                //specified on the @Transactional. I also tested, @Transactional will commit with just the class name
-                //without the full class + package, thus doing endsWith()
-                if( exceptionClassName.endsWith(className) ) {
-                    executeCommit = true;
-                    break;
-                }
-            }
-        }
-
-        return executeCommit;
     }
 }

--- a/javers-spring/src/main/java/org/javers/spring/auditable/aspect/JaversAuditableRepositoryAspect.java
+++ b/javers-spring/src/main/java/org/javers/spring/auditable/aspect/JaversAuditableRepositoryAspect.java
@@ -1,18 +1,21 @@
 package org.javers.spring.auditable.aspect;
 
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.javers.common.collections.Optional;
 import org.javers.core.Javers;
 import org.javers.spring.annotation.JaversSpringDataAuditable;
 import org.javers.spring.auditable.AspectUtil;
 import org.javers.spring.auditable.AuthorProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.Annotation;
 
 /**
  * Creates three @After advices.
@@ -43,19 +46,43 @@ public class JaversAuditableRepositoryAspect {
         this.javersCommitAdvice = javersCommitAdvice;
     }
 
-    @After("@annotation(org.javers.spring.annotation.JaversAuditable)")
+    @AfterReturning("@annotation(org.javers.spring.annotation.JaversAuditable)")
     public void commitAdvice(JoinPoint pjp) {
         javersCommitAdvice.commitMethodArguments(pjp);
     }
 
-    @After("execution(public * delete(..)) && this(org.springframework.data.repository.CrudRepository)")
+    @AfterThrowing(value = "@annotation(org.javers.spring.annotation.JaversAuditable)", throwing = "ex")
+    public void commitAdvice(JoinPoint pjp, Throwable ex) {
+        //If we are supposed to still execute, despite the exception, do so
+        if( isStillExecute(pjp, ex) ) {
+            commitAdvice(pjp);
+        }
+    }
+
+    @AfterReturning("execution(public * delete(..)) && this(org.springframework.data.repository.CrudRepository)")
     public void onDeleteExecuted(JoinPoint pjp)  {
         onVersionEvent(pjp, deleteHandler);
     }
 
-    @After("execution(public * save(..)) && this(org.springframework.data.repository.CrudRepository)")
+    @AfterThrowing(value = "execution(public * delete(..)) && this(org.springframework.data.repository.CrudRepository)", throwing = "ex")
+    public void onDeleteExecuted(JoinPoint pjp, Throwable ex)  {
+        //If we are supposed to still execute, despite the exception, do so
+        if( isStillExecute(pjp, ex) ) {
+            onDeleteExecuted(pjp);
+        }
+    }
+
+    @AfterReturning("execution(public * save(..)) && this(org.springframework.data.repository.CrudRepository)")
     public void onSaveExecuted(JoinPoint pjp) {
         onVersionEvent(pjp, saveHandler);
+    }
+
+    @AfterThrowing(value = "execution(public * save(..)) && this(org.springframework.data.repository.CrudRepository)", throwing = "ex")
+    public void onSaveExecuted(JoinPoint pjp, Throwable ex) {
+        //If we are supposed to still execute, despite the exception, do so
+        if( isStillExecute(pjp, ex) ) {
+            onSaveExecuted(pjp);
+        }
     }
 
     private void onVersionEvent(JoinPoint pjp, AuditChangeHandler handler) {
@@ -93,4 +120,55 @@ public class JaversAuditableRepositoryAspect {
         handler.handle(metadata, domainObject);
     }
 
+    /**
+     * Returns TRUE if the {@link Throwable} matches against the current {@link JoinPoint}s method with Spring's @{@link Transactional}
+     * noRollbackFor or noRoolbackForClassName values.
+     *
+     * @param ex the {@link Throwable} which was thrown
+     * @param pjp the {@link JoinPoint} we are currently at
+     * @return TRUE if the advised method has @{@link Transactional} and will commit despite this @{@link Throwable}
+     */
+    protected boolean isStillExecute(JoinPoint pjp, Throwable ex) {
+        //Grab the current method signature we are operating on, and the Spring Transactional Annotation, if any
+        MethodSignature signature = (MethodSignature)pjp.getSignature();
+        Transactional transactionalAnnotation = signature.getMethod().getAnnotation(Transactional.class);
+
+        // If there is no Spring @Transactional annotation on the method, then we don't want to execute the normal
+        // versioning code
+        if( transactionalAnnotation == null ) {
+            return false;
+        }
+
+        boolean executeCommit = false;
+        Class<? extends Throwable> exceptionClass = ex.getClass();
+        //grab the @Transactional noRollbackFor classes
+        Class<? extends Throwable>[] noRollbackForClasses = transactionalAnnotation.noRollbackFor();
+        if( noRollbackForClasses != null && noRollbackForClasses.length > 0 ) {
+            for( Class<? extends Throwable> aClass : noRollbackForClasses ) {
+                //if the exception class matches a class to NOT rollback for, match and break
+                if( aClass.equals(exceptionClass) ) {
+                    executeCommit = true;
+                    break;
+                }
+            }
+        }
+
+        //if we didn't match on a noRollbackFor classes, we need to check the noRollbackForClassName
+        if( !executeCommit ) {
+            String[] noRollbackForClassNames = transactionalAnnotation.noRollbackForClassName();
+            String exceptionClassName = exceptionClass.getName();
+            for( String className : noRollbackForClassNames ) {
+                //if the exception class name (will be fully qualified class + package) ends with the specified class
+                //name, it'll either match the base class name, or the fully qualified class + package, whichever was
+                //specified on the @Transactional. I also tested, @Transactional will commit with just the class name
+                //without the full class + package, thus doing endsWith()
+                if( exceptionClassName.endsWith(className) ) {
+                    executeCommit = true;
+                    break;
+                }
+            }
+        }
+
+        return executeCommit;
+    }
 }


### PR DESCRIPTION
Solution is to use @AfterReturning which only runs on a normal method exit, and @AfterThrowing which checks if @Transactional was used on the @Repository method, and if noRollbackFor or noRollbackForClassName is configured (still commit even if these Exceptions/Throwables are thrown) and matches the current Throwable, still proceed with the versioning.

I looked at updating JaversAuditableRepositoryAspectTest, but frankly I'm unsure how I'd even go about testing this kind of behavior, especially given I'm completely unfamiliar with Spock and only somewhat know Groovy. If you need me to update the test I'll be happy to, but some direction on what documentation bits might be useful for me to start with would be greatly appreciated.