### PR TITLE
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() shou…

### DIFF
--- a/javers-core/src/main/java/org/javers/common/collections/Lists.java
+++ b/javers-core/src/main/java/org/javers/common/collections/Lists.java
@@ -11,7 +11,7 @@ public class Lists {
 
     public static List wrapNull(List list){
         if (list == null){
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         return list;
     }

--- a/javers-core/src/main/java/org/javers/common/collections/Maps.java
+++ b/javers-core/src/main/java/org/javers/common/collections/Maps.java
@@ -14,7 +14,7 @@ public class Maps {
      */
     public static <K,V> Set<K> commonKeys(Map<K,V> left, Map<K,V> right) {
         if (left == null || right == null) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         return Sets.intersection(left.keySet(),right.keySet());
@@ -25,7 +25,7 @@ public class Maps {
      */
     public static <K,V> Set<K> keysDifference(Map<K,V> left, Map<K,V> right) {
         if (left == null){
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         if (right == null){

--- a/javers-core/src/main/java/org/javers/core/diff/DiffBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/diff/DiffBuilder.java
@@ -23,7 +23,7 @@ class DiffBuilder {
     }
 
     public static Diff empty() {
-        return new Diff(Collections.EMPTY_LIST);
+        return new Diff(Collections.<Change>emptyList());
     }
 
     public DiffBuilder addChange(Change change, Optional<Object> affectedCdo) {

--- a/javers-core/src/main/java/org/javers/core/diff/GraphPair.java
+++ b/javers-core/src/main/java/org/javers/core/diff/GraphPair.java
@@ -32,13 +32,13 @@ public class GraphPair {
 
         this.rightGraph = currentGraph;
 
-        this.onlyOnLeft = Collections.EMPTY_SET;
+        this.onlyOnLeft = Collections.emptySet();
         this.onlyOnRight = rightGraph.nodes();
     }
 
     private class EmptyGraph implements ObjectGraph {
         public Set<ObjectNode> nodes() {
-            return  Collections.EMPTY_SET;
+            return  Collections.emptySet();
         }
         public ObjectNode root() {
             throw new RuntimeException("not implemented");

--- a/javers-core/src/main/java/org/javers/core/diff/appenders/MapChangeAppender.java
+++ b/javers-core/src/main/java/org/javers/core/diff/appenders/MapChangeAppender.java
@@ -78,7 +78,7 @@ class MapChangeAppender extends CorePropertyChangeAppender<MapChange> {
         Map rightMap = MapType.mapStatic(rightRawMap, dehydrateFunction, owner);
 
         if (Objects.equals(leftMap, rightMap)) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         List<EntryChange> changes = new ArrayList<>();

--- a/javers-core/src/main/java/org/javers/core/diff/appenders/SetChangeAppender.java
+++ b/javers-core/src/main/java/org/javers/core/diff/appenders/SetChangeAppender.java
@@ -42,7 +42,7 @@ class SetChangeAppender extends CorePropertyChangeAppender<SetChange> {
         DehydrateContainerFunction dehydrateFunction = new DehydrateContainerFunction(itemType, globalIdFactory);
 
         if (Objects.equals(leftRawSet, rightRawSet)) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         Set leftSet = (Set) setType.map(leftRawSet, dehydrateFunction, owner);

--- a/javers-core/src/main/java/org/javers/core/metamodel/clazz/ClientsClassDefinitionBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/clazz/ClientsClassDefinitionBuilder.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public abstract class ClientsClassDefinitionBuilder<T extends ClientsClassDefinitionBuilder> {
     private Class<?> clazz;
-    private List<String> ignoredProperties = Collections.EMPTY_LIST;
+    private List<String> ignoredProperties = Collections.emptyList();
     private Optional<String> typeName = Optional.empty();
 
     ClientsClassDefinitionBuilder(Class<?> clazz) {

--- a/javers-core/src/main/java/org/javers/core/metamodel/object/CdoSnapshotBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/object/CdoSnapshotBuilder.java
@@ -23,7 +23,7 @@ public class CdoSnapshotBuilder {
     private CdoSnapshotStateBuilder stateBuilder = cdoSnapshotState();
     private CdoSnapshot previous;
     private boolean markAllAsChanged;
-    private List<String> changed = Collections.EMPTY_LIST;
+    private List<String> changed = Collections.emptyList();
     private ManagedType managedType;
     private long version;
 

--- a/javers-core/src/main/java/org/javers/core/snapshot/ShadowGraph.java
+++ b/javers-core/src/main/java/org/javers/core/snapshot/ShadowGraph.java
@@ -15,7 +15,7 @@ import java.util.Set;
 public class ShadowGraph implements ObjectGraph {
     private final Set<ObjectNode> snapshots;
 
-    public static ShadowGraph EMPTY = new ShadowGraph(Collections.EMPTY_SET);
+    public static ShadowGraph EMPTY = new ShadowGraph(Collections.<ObjectNode>emptySet());
 
     ShadowGraph(Set<ObjectNode> snapshots) {
         this.snapshots = snapshots;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1596

Please let me know if you have any questions.

M-Ezzat