### PR TITLE
fix bug that causes PropertyChange#equals to always return false

### DIFF
--- a/javers-core/src/main/java/org/javers/core/diff/changetype/PropertyChange.java
+++ b/javers-core/src/main/java/org/javers/core/diff/changetype/PropertyChange.java
@@ -36,7 +36,7 @@ public abstract class PropertyChange extends Change {
         if (this == o) {
             return true;
         }
-        if (o instanceof ObjectRemoved) {
+        if (o instanceof PropertyChange) {
             PropertyChange that = (PropertyChange) o;
             return super.equals(that) &&
                     Objects.equals(this.propertyName, that.propertyName);


### PR DESCRIPTION
Sorry I haven't written a test, but I've not really done much Groovy and it's 20:58 on a Friday evening and I'm watching TV!