### PR TITLE
Fix TypeMapperState.mappedTypes. 

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/type/TypeMapperState.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/TypeMapperState.java
@@ -21,7 +21,7 @@ import static org.javers.common.validation.Validate.argumentsAreNotNull;
  * @author bartosz.walacik
  */
 class TypeMapperState {
-    private final Map<Type, JaversType> mappedTypes = new ConcurrentHashMap<>();
+    private final Map<String, JaversType> mappedTypes = new ConcurrentHashMap<>();
     private final Map<DuckType, Class> mappedTypeNames = new ConcurrentHashMap<>();
     private final TypeFactory typeFactory;
     private final ValueType OBJECT_TYPE = new ValueType(Object.class);
@@ -67,7 +67,7 @@ class TypeMapperState {
     }
 
     boolean contains(Type javaType){
-        return mappedTypes.get(javaType) != null;
+        return mappedTypes.get(javaType.getTypeName()) != null;
     }
 
     JaversType getJaversType(Type javaType) {
@@ -77,7 +77,7 @@ class TypeMapperState {
             return OBJECT_TYPE;
         }
 
-        JaversType jType = mappedTypes.get(javaType);
+        JaversType jType = mappedTypes.get(javaType.getTypeName());
         if (jType != null) {
             return jType;
         }
@@ -110,7 +110,7 @@ class TypeMapperState {
 
         synchronized (javaType) {
             //map.contains double check
-            JaversType mappedType = mappedTypes.get(javaType);
+            JaversType mappedType = mappedTypes.get(javaType.getTypeName());
             if (mappedType != null) {
                 return mappedType;
             }
@@ -143,7 +143,7 @@ class TypeMapperState {
      * must be called within synchronized block
      */
     private void addFullMapping(Type javaType, JaversType newType){
-        mappedTypes.put(javaType, newType);
+        mappedTypes.put(javaType.getTypeName(), newType);
 
         if (newType instanceof ManagedType){
             ManagedType managedType = (ManagedType)newType;


### PR DESCRIPTION
Class loaded by different classLoader are not equal, so using Class as map key will have mare than one entry in that map. Use type name instead.

The failed test case could be reproduce when work with Spring-Boot 1.3+ and DevTools.