### PR TITLE
Added scanTypeNames() using FastClasspathScanner Library

### DIFF
--- a/javers-core/build.gradle
+++ b/javers-core/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.2'
     compile 'com.google.code.gson:gson:2.5'
     compile 'org.picocontainer:picocontainer:2.14.3'
+	compile group: 'io.github.lukehutch', name: 'fast-classpath-scanner', version: '2.0.3'
+
 
     testCompile 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final'
     testCompile 'com.google.guava:guava:18.0'

--- a/javers-core/src/main/java/org/javers/common/exception/JaversExceptionCode.java
+++ b/javers-core/src/main/java/org/javers/common/exception/JaversExceptionCode.java
@@ -15,6 +15,8 @@ public enum JaversExceptionCode {
     ENTITY_WITHOUT_ID ("Class '%s' mapped as Entity has no Id property. Use @Id annotation to mark unique and not-null Entity identifier"),
 
     ENTITY_INSTANCE_WITH_NULL_ID("Found Entity instance '%s' with null idProperty '%s'"),
+    
+    CANT_FIND_CLASS_WITH_TYPENAME("Can't extract type for '%s' class with @TypeName annotation during scanTypeNames()"),
 
     NOT_INSTANCE_OF(JaversException.BOOTSTRAP_ERROR + "expected instance of '%s', got instance of '%s'"),
 

--- a/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
+++ b/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
@@ -185,7 +185,7 @@ public class ReflectionUtil {
         return Lists.immutableListOf(((ParameterizedType) javaType).getActualTypeArguments());
     }
     
-    public static Class<?>[] getClasses(Class<?> annotation, String... paths) {
+    public static List<Class<?>> getClasses(Class<?> annotation, String... paths) {
     	List<String> names = new FastClasspathScanner(paths).scan().getNamesOfClassesWithAnnotation(annotation);
     	List<Class<?>> classes = new ArrayList<Class<?>>();
     	for (String c : names) {
@@ -197,7 +197,7 @@ public class ReflectionUtil {
 			}
     		classes.add(classType);
     	}
-    	return null;
+    	return classes;
     }
 
     public static Optional<Type> isConcreteType(Type javaType){

--- a/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
+++ b/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
@@ -1,5 +1,22 @@
 package org.javers.common.reflection;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.javers.common.collections.Lists;
 import org.javers.common.collections.Optional;
 import org.javers.common.collections.Primitives;
@@ -9,17 +26,7 @@ import org.javers.common.validation.Validate;
 import org.javers.core.Javers;
 import org.slf4j.Logger;
 
-import java.io.File;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
-import java.math.BigDecimal;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-
-import static org.slf4j.LoggerFactory.getLogger;
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 
 /**
  * @author bartosz walacik
@@ -178,50 +185,19 @@ public class ReflectionUtil {
         return Lists.immutableListOf(((ParameterizedType) javaType).getActualTypeArguments());
     }
     
-    public static Class<?>[] getClasses(String packageName) {
-		ClassLoader classLoader = Javers.class.getClassLoader();
-		assert classLoader != null;
-		Enumeration<URL> resources;
-		List<Class<?>> classes = new ArrayList<Class<?>>();
-		try {
-			String path = packageName.replace('.', '/');
-			resources = classLoader.getResources(path);
-			List<File> dirs = new ArrayList<File>();
-			while (resources.hasMoreElements()) {
-				URL resource = (URL) resources.nextElement();
-				dirs.add(new File(resource.getFile()));
+    public static Class<?>[] getClasses(Class<?> annotation, String... paths) {
+    	List<String> names = new FastClasspathScanner(paths).scan().getNamesOfClassesWithAnnotation(annotation);
+    	List<Class<?>> classes = new ArrayList<Class<?>>();
+    	for (String c : names) {
+    		Class<?> classType;
+			try {
+				classType = Class.forName(c);
+			} catch (ClassNotFoundException e) {
+				throw new JaversException(JaversExceptionCode.CANT_FIND_CLASS_WITH_TYPENAME, c);
 			}
-			for (File directory : dirs) {
-				classes.addAll(findClasses(directory, packageName));
-			}
-		} catch (Throwable ex) {
-			throw new RuntimeException(ex);
-		}
-		return classes.toArray(new Class[classes.size()]);
-	}
-    /**
-     * Recursive method used to find all classes in a given directory and subdirs.
-     *
-     * @param directory   The base directory
-     * @param packageName The package name for classes found inside the base directory
-     * @return The classes
-     * @throws ClassNotFoundException
-     */
-    private static List<Class<?>> findClasses(File directory, String packageName) throws ClassNotFoundException {
-        List<Class<?>> classes = new ArrayList<Class<?>>();
-        if (!directory.exists()) {
-            return classes;
-        }
-        File[] files = directory.listFiles();
-        for (File file : files) {
-            if (file.isDirectory()) {
-                assert !file.getName().contains(".");
-                classes.addAll(findClasses(file, packageName + "." + file.getName()));
-            } else if (file.getName().endsWith(".class")) {
-                classes.add(Class.forName(packageName + '.' + file.getName().substring(0, file.getName().length() - 6)));
-            }
-        }
-        return classes;
+    		classes.add(classType);
+    	}
+    	return null;
     }
 
     public static Optional<Type> isConcreteType(Type javaType){

--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -238,14 +238,15 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * (without getting TYPE_NAME_NOT_FOUND exception).
      */
     public JaversBuilder scanTypeNames(String packagesToScan){
-    	if(packagesToScan==null || packagesToScan.trim().isEmpty())
-    		return this;
-		
-		Class<?>[] list = ReflectionUtil.getClasses(TypeName.class, packagesToScan.split(","));
-		for (Class<?> c : list) {
-			scanTypeName(c);
-		}
-		return this;
+        if(packagesToScan==null || packagesToScan.trim().isEmpty()) {
+            return this;
+        }
+        
+        List<Class<?>> list = ReflectionUtil.getClasses(TypeName.class, packagesToScan.split(","));
+        for (Class<?> c : list) {
+            scanTypeName(c);
+        }
+        return this;
     }
 
     /**

--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -241,7 +241,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
     	if(packagesToScan==null || packagesToScan.trim().isEmpty())
     		return this;
 		
-		Class<?>[] list = ReflectionUtil.getClasses(TypeName.class, packagesToScan);
+		Class<?>[] list = ReflectionUtil.getClasses(TypeName.class, packagesToScan.split(","));
 		for (Class<?> c : list) {
 			scanTypeName(c);
 		}

--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -240,14 +240,12 @@ public class JaversBuilder extends AbstractContainerBuilder {
     public JaversBuilder scanTypeNames(String packagesToScan){
     	if(packagesToScan==null || packagesToScan.trim().isEmpty())
     		return this;
-		for (String packageName : packagesToScan.split(",")) {
-			Class<?>[] list = ReflectionUtil.getClasses(packageName);
-			for (Class<?> c : list) {
-				if (c.isAnnotationPresent(TypeName.class))
-					scanTypeName(c);
-			}
+		
+		Class<?>[] list = ReflectionUtil.getClasses(TypeName.class, packagesToScan);
+		for (Class<?> c : list) {
+			scanTypeName(c);
 		}
-    	return this;
+		return this;
     }
 
     /**

--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -233,22 +233,21 @@ public class JaversBuilder extends AbstractContainerBuilder {
     }
 
     /**
-     * <b>Not implemented!</b>
-     * <br/><br/>
-     *
-     * <i>If implemented, allows you to register all your classes with &#64;{@link TypeName} annotation
-     * (within given package) in order to use them in all kinds of JQL queries <br/>
+     * Allows you to register all your classes with &#64;{@link TypeName} annotation
+     * (within given comma separated list of packages) in order to use them in all kinds of JQL queries <br/>
      * (without getting TYPE_NAME_NOT_FOUND exception).
-     * </i>
-     * <br/><br/>
-     *
-     * If you think that this method should be implemented,
-     * vote here: <a href="https://github.com/javers/javers/issues/263">issue/263</a>
      */
-    public JaversBuilder scanTypeNames(String packageToScan){
-        throw new RuntimeException("JaversBuilder.scanTypeNames(String packageToScan) is not implemented! " +
-                "If you think that this method should be implemented, " +
-                "vote here: https://github.com/javers/javers/issues/263");
+    public JaversBuilder scanTypeNames(String packagesToScan){
+    	if(packagesToScan==null || packagesToScan.trim().isEmpty())
+    		return this;
+		for (String packageName : packagesToScan.split(",")) {
+			Class<?>[] list = ReflectionUtil.getClasses(packageName);
+			for (Class<?> c : list) {
+				if (c.isAnnotationPresent(TypeName.class))
+					scanTypeName(c);
+			}
+		}
+    	return this;
     }
 
     /**

--- a/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
@@ -23,7 +23,7 @@ class ReflectionUtilTest extends Specification {
         given:
 
         when:
-        def list = ReflectionUtil.getClasses(TypeName.class, "org.javers.core.examples.typeNames"")
+        def list = ReflectionUtil.getClasses(TypeName.class, "org.javers.core.examples.typeNames")
 
         then:
         list instanceof List<Class<?>>

--- a/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
@@ -18,6 +18,17 @@ class ReflectionUtilTest extends Specification {
         ReflectionUtil.isAnnotationPresentInHierarchy(IgnoredSubType, DiffIgnore)
         !ReflectionUtil.isAnnotationPresentInHierarchy(ArrayList, DiffIgnore)
     }
+    
+    def "should instantiate via public constructor with ArgumentsResolver"() {
+        given:
+
+        when:
+        def list = ReflectionUtil.getClasses(TypeName.class, ""org.javers.core.examples.typeNames"")
+
+        then:
+        list instanceof List<Class<?>>
+        list.size() == 8
+    }
 
     def "should instantiate via public constructor with ArgumentsResolver"() {
         given:

--- a/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
@@ -23,7 +23,7 @@ class ReflectionUtilTest extends Specification {
         given:
 
         when:
-        def list = ReflectionUtil.getClasses(TypeName.class, ""org.javers.core.examples.typeNames"")
+        def list = ReflectionUtil.getClasses(TypeName.class, "org.javers.core.examples.typeNames"")
 
         then:
         list instanceof List<Class<?>>

--- a/javers-core/src/test/groovy/org/javers/core/JaversBuilderTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversBuilderTest.groovy
@@ -25,6 +25,16 @@ import static org.javers.core.JaversBuilder.javers
  */
 class JaversBuilderTest extends Specification {
 
+    def "should scan given Package"() {
+        when:
+        def javers = JaversTestBuilder.javersTestAssembly("org.javers.core.examples.typeNames")
+        def typeMapper = javers.typeMapper
+
+        then:
+        typeMapper.getJaversManagedType("myName").baseJavaClass == NewEntityWithTypeAlias
+        typeMapper.getJaversManagedType("org.javers.core.examples.typeNames.OldEntity").baseJavaClass == NewEntity
+    }
+
     def "should scan given Entity"() {
         when:
         def javers = JaversTestBuilder.javersTestAssembly(NewEntityWithTypeAlias)
@@ -33,7 +43,6 @@ class JaversBuilderTest extends Specification {
         then:
         typeMapper.getJaversManagedType("myName").baseJavaClass == NewEntityWithTypeAlias
     }
-
 
     def "should manage Entity"() {
         when:

--- a/javers-core/src/test/groovy/org/javers/core/JaversTestBuilder.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversTestBuilder.groovy
@@ -56,12 +56,21 @@ class JaversTestBuilder {
         javersBuilder.scanTypeName(classToScan).build()
     }
 
+    private JaversTestBuilder (String packagesToScan) {
+        javersBuilder = new JaversBuilder()
+        javersBuilder.scanTypeNames(packagesToScan).build()
+    }
+
     static JaversTestBuilder javersTestAssembly(){
         new JaversTestBuilder(MappingStyle.FIELD)
     }
 
     static JaversTestBuilder javersTestAssembly(Class classToScan){
         new JaversTestBuilder(classToScan)
+    }
+
+    static JaversTestBuilder javersTestAssembly(String packagesToScan){
+        new JaversTestBuilder(packagesToScan)
     }
 
     static JaversTestBuilder javersTestAssembly(JaversRepository javersRepository){

--- a/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoAutoConfiguration.java
+++ b/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoAutoConfiguration.java
@@ -59,6 +59,7 @@ public class JaversMongoAutoConfiguration {
                 .withPrettyPrint(javersProperties.isPrettyPrint())
                 .withTypeSafeValues(javersProperties.isTypeSafeValues())
                 .registerJaversRepository(javersRepository)
+                .scanTypeNames(javersProperties.getPackagesToScan())
                 .build();
     }
 

--- a/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversProperties.java
+++ b/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversProperties.java
@@ -13,6 +13,7 @@ public class JaversProperties {
     private boolean newObjectSnapshot = false;
     private boolean prettyPrint = true;
     private boolean typeSafeValues = false;
+    private String packagesToScan = "";
 
     public String getAlgorithm() {
         return algorithm;
@@ -53,4 +54,12 @@ public class JaversProperties {
     public void setTypeSafeValues(boolean typeSafeValues) {
         this.typeSafeValues = typeSafeValues;
     }
+
+	public String getPackagesToScan() {
+		return packagesToScan;
+	}
+
+	public void setPackagesToScan(String packagesToScan) {
+		this.packagesToScan = packagesToScan;
+	}
 }

--- a/javers-spring-boot-starter-mongo/src/test/java/org/javers/spring/boot/mongo/TestApplication.java
+++ b/javers-spring-boot-starter-mongo/src/test/java/org/javers/spring/boot/mongo/TestApplication.java
@@ -29,7 +29,7 @@ public class TestApplication {
         return new CommitPropertiesProvider() {
             @Override
             public Map<String, String> provide() {
-                Map props = new HashMap();
+                Map<String, String> props = new HashMap<String, String>();
                 props.put("key", "ok");
                 return props;
             }

--- a/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversProperties.java
+++ b/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversProperties.java
@@ -1,6 +1,5 @@
 package org.javers.spring.boot.sql;
 
-import org.javers.repository.sql.DialectName;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "javers")
@@ -11,6 +10,7 @@ public class JaversProperties {
     private boolean newObjectSnapshot = false;
     private boolean prettyPrint = true;
     private boolean typeSafeValues = false;
+    private String packagesToScan = "";
 
     public String getAlgorithm() {
         return algorithm;
@@ -51,5 +51,13 @@ public class JaversProperties {
     public void setTypeSafeValues(boolean typeSafeValues) {
         this.typeSafeValues = typeSafeValues;
     }
+
+	public String getPackagesToScan() {
+		return packagesToScan;
+	}
+
+	public void setPackagesToScan(String packagesToScan) {
+		this.packagesToScan = packagesToScan;
+	}
 
 }

--- a/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversSqlAutoConfiguration.java
+++ b/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversSqlAutoConfiguration.java
@@ -50,9 +50,6 @@ public class JaversSqlAutoConfiguration {
     @Autowired
     private EntityManagerFactory entityManagerFactory;
 
-    @Autowired
-    private CommitPropertiesProvider commitPropertiesProvider;
-
     @Bean
     public DialectName javersSqlDialectName(){
         SessionFactoryImplementor sessionFactory =
@@ -82,6 +79,7 @@ public class JaversSqlAutoConfiguration {
                 .withNewObjectsSnapshot(javersProperties.isNewObjectSnapshot())
                 .withPrettyPrint(javersProperties.isPrettyPrint())
                 .withTypeSafeValues(javersProperties.isTypeSafeValues())
+                .scanTypeNames(javersProperties.getPackagesToScan())
                 .build();
     }
 

--- a/javers-spring-boot-starter-sql/src/test/java/org/javers/spring/boot/sql/TestApplication.java
+++ b/javers-spring-boot-starter-sql/src/test/java/org/javers/spring/boot/sql/TestApplication.java
@@ -1,14 +1,13 @@
 package org.javers.spring.boot.sql;
 
-import com.google.common.collect.Maps;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.javers.spring.auditable.CommitPropertiesProvider;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author pawelszymczyk
@@ -22,7 +21,7 @@ public class TestApplication {
         return new CommitPropertiesProvider() {
             @Override
             public Map<String, String> provide() {
-                Map props = new HashMap();
+                Map<String, String> props = new HashMap<String, String>();
                 props.put("key", "ok");
                 return props;
             }


### PR DESCRIPTION
JaversBuilder now supports scanTypeNames() using FastClasspathScanner Library. Default implementations of JaversMongoAutoConfiguration and JaversSqlAutoConfiguration support package scanning using `packagesToScan` configuration property. `packagesToScan` supports multiple values separated by comma

Resolving https://github.com/javers/javers/issues/263