### PR TITLE
#398 Define schema for javers related tables 

### DIFF
--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/SqlRepositoryBuilder.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/SqlRepositoryBuilder.java
@@ -16,6 +16,9 @@ import java.sql.SQLException;
 public class SqlRepositoryBuilder extends AbstractContainerBuilder {
     private static final Logger logger = LoggerFactory.getLogger(SqlRepositoryBuilder.class);
 
+    public static String SCHEMA_NAME = "";
+    public static final String SCHEMA_TABLE_SEP = ".";
+
     private DialectName dialectName;
     private ConnectionProvider connectionProvider;
 
@@ -33,6 +36,20 @@ public class SqlRepositoryBuilder extends AbstractContainerBuilder {
 
     public SqlRepositoryBuilder withConnectionProvider(ConnectionProvider connectionProvider){
         this.connectionProvider = connectionProvider;
+        return this;
+    }
+
+    /**
+     * This function sets a schema to be used for creation and updating tables. When passing a schema name make sure
+     * that the schema has been created in the database before running JaVers.
+     *
+     * Example: CREATE SCHEMA my_schema_name AUTHORIZATION my_db;
+     *
+     * @param schemaName
+     * @return
+     */
+    public SqlRepositoryBuilder withSchema(String schemaName){
+        SCHEMA_NAME = schemaName;
         return this;
     }
 

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/CdoSnapshotFinder.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/CdoSnapshotFinder.java
@@ -110,7 +110,7 @@ public class CdoSnapshotFinder {
     private Optional<Long> selectMaxSnapshotPrimaryKey(long globalIdPk) {
         SelectQuery query = polyJDBC.query()
             .select("MAX(" + SNAPSHOT_PK + ")")
-            .from(SNAPSHOT_TABLE_NAME)
+            .from(getSnapshotTableName())
             .where(SNAPSHOT_GLOBAL_ID_FK + " = :globalIdPk")
             .withArgument("globalIdPk", globalIdPk);
 

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/CommitPropertyFinder.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/CommitPropertyFinder.java
@@ -28,7 +28,7 @@ public class CommitPropertyFinder {
 
         SelectQuery query = polyJDBC.query()
             .select(COMMIT_PROPERTY_COMMIT_FK + ", " + COMMIT_PROPERTY_NAME + ", " + COMMIT_PROPERTY_VALUE)
-            .from(COMMIT_PROPERTY_TABLE_NAME)
+            .from(getCommitPropertyTableName())
             .where(COMMIT_PROPERTY_COMMIT_FK + " in (" + Joiner.on(",").join(commitPKs) + ")");
         return polyJDBC.queryRunner().queryList(query, new ObjectMapper<CommitPropertyDTO>() {
             @Override

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/ManagedClassFilter.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/ManagedClassFilter.java
@@ -26,8 +26,8 @@ class ManagedClassFilter extends SnapshotFilter {
             query.where(
             "(    " + SNAPSHOT_MANAGED_TYPE + " = :managedType "+
             "  OR g.owner_id_fk in ( "+
-            "     select g1." + GLOBAL_ID_PK + " from " + SNAPSHOT_TABLE_NAME + " s1 "+
-            "     INNER JOIN " + GLOBAL_ID_TABLE_NAME + " g1 ON g1." + GLOBAL_ID_PK + "= s1."+ SNAPSHOT_GLOBAL_ID_FK +
+            "     select g1." + GLOBAL_ID_PK + " from " + getSnapshotTableName() + " s1 "+
+            "     INNER JOIN " + getGlobalIdTableName() + " g1 ON g1." + GLOBAL_ID_PK + "= s1."+ SNAPSHOT_GLOBAL_ID_FK +
             "     and  s1.managed_type = :managedType)"+
             ")");
         }

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/SnapshotFilter.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/SnapshotFilter.java
@@ -12,10 +12,10 @@ import static org.javers.repository.sql.schema.FixedSchemaFactory.*;
 
 abstract class SnapshotFilter {
     static final String FROM_COMMIT_WITH_SNAPSHOT =
-            SNAPSHOT_TABLE_NAME +
-            " INNER JOIN " + COMMIT_TABLE_NAME + " ON " + COMMIT_PK + " = " + SNAPSHOT_COMMIT_FK +
-            " INNER JOIN " + GLOBAL_ID_TABLE_NAME + " g ON g." + GLOBAL_ID_PK + " = " + SNAPSHOT_GLOBAL_ID_FK +
-            " LEFT OUTER JOIN " + GLOBAL_ID_TABLE_NAME + " o ON o." + GLOBAL_ID_PK + " = g." + GLOBAL_ID_OWNER_ID_FK;
+            getSnapshotTableName() +
+            " INNER JOIN " + getCommitTableName() + " ON " + COMMIT_PK + " = " + SNAPSHOT_COMMIT_FK +
+            " INNER JOIN " + getGlobalIdTableName() + " g ON g." + GLOBAL_ID_PK + " = " + SNAPSHOT_GLOBAL_ID_FK +
+            " LEFT OUTER JOIN " + getGlobalIdTableName() + " o ON o." + GLOBAL_ID_PK + " = g." + GLOBAL_ID_OWNER_ID_FK;
 
     private static final String BASE_FIELDS =
         SNAPSHOT_STATE + ", " +
@@ -109,7 +109,7 @@ abstract class SnapshotFilter {
 
     private void addCommitPropertyCondition(SelectQuery query, String propertyName, String propertyValue) {
         query.append(" AND EXISTS (" +
-            "SELECT * FROM " + COMMIT_PROPERTY_TABLE_NAME +
+            "SELECT * FROM " + getCommitPropertyTableName() +
             " WHERE " + COMMIT_PROPERTY_COMMIT_FK + " = " + COMMIT_PK +
             " AND " + COMMIT_PROPERTY_NAME + " = :propertyName_" + propertyName +
             " AND " + COMMIT_PROPERTY_VALUE + " = :propertyValue_" + propertyName +

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/CdoSnapshotRepository.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/CdoSnapshotRepository.java
@@ -29,7 +29,7 @@ public class CdoSnapshotRepository {
     }
 
     private long insertSnapshot(long globalIdPk, long commitIdPk, CdoSnapshot cdoSnapshot) {
-        InsertQuery query = javersPolyJDBC.query().insert().into(SNAPSHOT_TABLE_NAME)
+        InsertQuery query = javersPolyJDBC.query().insert().into(getSnapshotTableName())
                 .value(SNAPSHOT_TYPE, cdoSnapshot.getType().toString())
                 .value(SNAPSHOT_GLOBAL_ID_FK, globalIdPk)
                 .value(SNAPSHOT_COMMIT_FK, commitIdPk)
@@ -37,7 +37,7 @@ public class CdoSnapshotRepository {
                 .value(SNAPSHOT_STATE, jsonConverter.toJson(cdoSnapshot.getState()))
                 .value(SNAPSHOT_CHANGED, jsonConverter.toJson(cdoSnapshot.getChanged() ))
                 .value(SNAPSHOT_MANAGED_TYPE, cdoSnapshot.getManagedType().getName())
-                .sequence(SNAPSHOT_PK, SNAPSHOT_TABLE_PK_SEQ);
+                .sequence(SNAPSHOT_PK, getSnapshotTablePkSeq());
 
         return javersPolyJDBC.queryRunner().insert(query);
     }

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/CommitMetadataRepository.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/CommitMetadataRepository.java
@@ -33,18 +33,18 @@ public class CommitMetadataRepository {
     }
 
     private long insertCommit(String author, LocalDateTime date, CommitId commitId) {
-        InsertQuery query = polyJDBC.query().insert().into(COMMIT_TABLE_NAME)
+        InsertQuery query = polyJDBC.query().insert().into(getCommitTableName())
                 .value(COMMIT_AUTHOR, author)
                 .value(COMMIT_COMMIT_DATE, toTimestamp(date))
                 .value(COMMIT_COMMIT_ID, commitId.valueAsNumber())
-                .sequence(COMMIT_PK, COMMIT_PK_SEQ);
+                .sequence(COMMIT_PK, getCommitPkSeq());
 
         return polyJDBC.queryRunner().insert(query);
     }
 
     private void insertCommitProperties(long commitPk, Map<String, String> properties) {
         for (Map.Entry<String, String> property : properties.entrySet()) {
-            InsertQuery query = polyJDBC.query().insert().into(COMMIT_PROPERTY_TABLE_NAME)
+            InsertQuery query = polyJDBC.query().insert().into(getCommitPropertyTableName())
                 .value(COMMIT_PROPERTY_COMMIT_FK, commitPk)
                 .value(COMMIT_PROPERTY_NAME, property.getKey())
                 .value(COMMIT_PROPERTY_VALUE, property.getValue());
@@ -55,7 +55,7 @@ public class CommitMetadataRepository {
     public boolean isPersisted(Commit commit) {
         SelectQuery selectQuery = polyJDBC.query()
                 .select("count(*)")
-                .from(COMMIT_TABLE_NAME)
+                .from(getCommitTableName())
                 .where(COMMIT_COMMIT_ID + " = :id")
                 .withArgument("id", commit.getId().valueAsNumber());
 
@@ -75,7 +75,7 @@ public class CommitMetadataRepository {
     private Optional<BigDecimal> selectMaxCommitId() {
         SelectQuery query = polyJDBC.query()
                 .select("MAX(" + COMMIT_COMMIT_ID + ")")
-                .from(COMMIT_TABLE_NAME);
+                .from(getCommitTableName());
 
         return queryForOptionalBigDecimal(query, polyJDBC);
     }

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/GlobalIdRepository.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/GlobalIdRepository.java
@@ -56,7 +56,7 @@ public class GlobalIdRepository {
 
     private Optional<Long> findGlobalIdPkInDB(GlobalId globalId) {
 
-        SelectQuery query = polyJdbc.query().select(GLOBAL_ID_PK).from(GLOBAL_ID_TABLE_NAME);
+        SelectQuery query = polyJdbc.query().select(GLOBAL_ID_PK).from(getGlobalIdTableName());
 
         if (globalId instanceof ValueObjectId) {
             ValueObjectId valueObjectId  = (ValueObjectId) globalId;
@@ -89,7 +89,7 @@ public class GlobalIdRepository {
     private long insert(GlobalId globalId) {
         InsertQuery query = polyJdbc.query()
             .insert()
-            .into(GLOBAL_ID_TABLE_NAME);
+            .into(getGlobalIdTableName());
 
 
         if (globalId instanceof ValueObjectId) {
@@ -107,7 +107,7 @@ public class GlobalIdRepository {
             query.value(GLOBAL_ID_TYPE_NAME, globalId.getTypeName());
         }
 
-        query.sequence(GLOBAL_ID_PK, GLOBAL_ID_PK_SEQ);
+        query.sequence(GLOBAL_ID_PK, getGlobalIdPkSeq());
 
         return polyJdbc.queryRunner().insert(query);
     }

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/FixedSchemaFactory.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/FixedSchemaFactory.java
@@ -9,6 +9,9 @@ import org.polyjdbc.core.util.StringUtils;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static org.javers.repository.sql.SqlRepositoryBuilder.SCHEMA_NAME;
+import static org.javers.repository.sql.SqlRepositoryBuilder.SCHEMA_TABLE_SEP;
+
 /**
  * non-configurable schema factory, gives you schema with default table names
  *
@@ -16,36 +19,38 @@ import java.util.TreeMap;
  */
 public class FixedSchemaFactory {
 
-    public static final String GLOBAL_ID_TABLE_NAME = "jv_global_id";
+    private static final String GLOBAL_ID_TABLE_NAME = "jv_global_id";
     public static final String GLOBAL_ID_PK =         "global_id_pk";
     public static final String GLOBAL_ID_LOCAL_ID =   "local_id";
     public static final String GLOBAL_ID_FRAGMENT =   "fragment";     //since 1.2
     public static final String GLOBAL_ID_TYPE_NAME =  "type_name";    //since 2.0
     public static final String GLOBAL_ID_OWNER_ID_FK ="owner_id_fk";  //since 1.2
-    public static final String GLOBAL_ID_PK_SEQ =     "jv_global_id_pk_seq";
+    private static final String GLOBAL_ID_PK_SEQ =     "jv_global_id_pk_seq";
 
-    public static final String COMMIT_TABLE_NAME =    "jv_commit";
+    private static final String COMMIT_TABLE_NAME =    "jv_commit";
     public static final String COMMIT_PK =            "commit_pk";
     public static final String COMMIT_AUTHOR =        "author";
     public static final String COMMIT_COMMIT_DATE =   "commit_date";
     public static final String COMMIT_COMMIT_ID =     "commit_id";
-    public static final String COMMIT_PK_SEQ =        "jv_commit_pk_seq";
+    private static final String COMMIT_PK_SEQ =        "jv_commit_pk_seq";
 
-    public static final String COMMIT_PROPERTY_TABLE_NAME = "jv_commit_property";
+    private static final String COMMIT_PROPERTY_TABLE_NAME = "jv_commit_property";
     public static final String COMMIT_PROPERTY_COMMIT_FK =  "commit_fk";
     public static final String COMMIT_PROPERTY_NAME =       "property_name";
     public static final String COMMIT_PROPERTY_VALUE =      "property_value";
 
-    public static final String SNAPSHOT_TABLE_NAME =   "jv_snapshot";
+    private static final String SNAPSHOT_TABLE_NAME =   "jv_snapshot";
     public static final String SNAPSHOT_PK =           "snapshot_pk";
     public static final String SNAPSHOT_COMMIT_FK =    "commit_fk";
     public static final String SNAPSHOT_GLOBAL_ID_FK = "global_id_fk";
     public static final String SNAPSHOT_TYPE =         "type";
     public static final String SNAPSHOT_VERSION =      "version";
-    public static final String SNAPSHOT_TABLE_PK_SEQ = "jv_snapshot_pk_seq";
+    private static final String SNAPSHOT_TABLE_PK_SEQ = "jv_snapshot_pk_seq";
     public static final String SNAPSHOT_STATE =        "state";
     public static final String SNAPSHOT_CHANGED =      "changed_properties"; //since v 1.2
     public static final String SNAPSHOT_MANAGED_TYPE = "managed_type";       //since 2.0
+
+    private static final String CDO_CLASS_TABLE_NAME = "jv_cdo_class";
 
     private final static int ORACLE_MAX_NAME_LEN = 30;
     private final Dialect dialect;
@@ -57,10 +62,10 @@ public class FixedSchemaFactory {
     Map<String, Schema> allTablesSchema(Dialect dialect) {
         Map<String, Schema> schema = new TreeMap<>();
 
-        schema.put(GLOBAL_ID_TABLE_NAME, globalIdTableSchema(dialect, GLOBAL_ID_TABLE_NAME));
-        schema.put(COMMIT_TABLE_NAME,    commitTableSchema(dialect, COMMIT_TABLE_NAME));
-        schema.put(COMMIT_PROPERTY_TABLE_NAME, commitPropertiesTableSchema(dialect, COMMIT_PROPERTY_TABLE_NAME));
-        schema.put(SNAPSHOT_TABLE_NAME,  snapshotTableSchema(dialect, SNAPSHOT_TABLE_NAME));
+        schema.put(GLOBAL_ID_TABLE_NAME, globalIdTableSchema(dialect, getGlobalIdTableName()));
+        schema.put(COMMIT_TABLE_NAME,    commitTableSchema(dialect, getCommitTableName()));
+        schema.put(COMMIT_PROPERTY_TABLE_NAME, commitPropertiesTableSchema(dialect, getCommitPropertyTableName()));
+        schema.put(SNAPSHOT_TABLE_NAME,  snapshotTableSchema(dialect, getSnapshotTableName()));
 
         return schema;
     }
@@ -74,8 +79,8 @@ public class FixedSchemaFactory {
                        .withAttribute().text(SNAPSHOT_STATE).and()
                        .withAttribute().text(SNAPSHOT_CHANGED).and()
                        .withAttribute().string(SNAPSHOT_MANAGED_TYPE).withMaxLength(200).and();
-        foreignKey(tableName, SNAPSHOT_GLOBAL_ID_FK, GLOBAL_ID_TABLE_NAME, GLOBAL_ID_PK, relationBuilder);
-        foreignKey(tableName, SNAPSHOT_COMMIT_FK, COMMIT_TABLE_NAME, COMMIT_PK, relationBuilder);
+        foreignKey(tableName, SNAPSHOT_GLOBAL_ID_FK, getGlobalIdTableName(), GLOBAL_ID_PK, relationBuilder);
+        foreignKey(tableName, SNAPSHOT_COMMIT_FK, getCommitTableName(), COMMIT_PK, relationBuilder);
         relationBuilder.build();
 
         columnsIndex(tableName, schema, SNAPSHOT_GLOBAL_ID_FK);
@@ -103,10 +108,10 @@ public class FixedSchemaFactory {
         Schema schema = new Schema(dialect);
         RelationBuilder relationBuilder = schema.addRelation(tableName);
         relationBuilder
-            .primaryKey(tableName + "_pk").using(COMMIT_PROPERTY_COMMIT_FK, COMMIT_PROPERTY_NAME).and()
+            .primaryKey(normaliseSchemaTableName(tableName) + "_pk").using(COMMIT_PROPERTY_COMMIT_FK, COMMIT_PROPERTY_NAME).and()
             .withAttribute().string(COMMIT_PROPERTY_NAME).withMaxLength(200).and()
             .withAttribute().string(COMMIT_PROPERTY_VALUE).withMaxLength(200).and();
-        foreignKey(tableName, COMMIT_PROPERTY_COMMIT_FK, COMMIT_TABLE_NAME, COMMIT_PK, relationBuilder);
+        foreignKey(tableName, COMMIT_PROPERTY_COMMIT_FK, getCommitTableName(), COMMIT_PK, relationBuilder);
         relationBuilder.build();
 
         columnsIndex(tableName, schema, COMMIT_PROPERTY_COMMIT_FK);
@@ -123,7 +128,7 @@ public class FixedSchemaFactory {
                 .withAttribute().string(GLOBAL_ID_LOCAL_ID).withMaxLength(200).and()
                 .withAttribute().string(GLOBAL_ID_FRAGMENT).withMaxLength(200).and()
                 .withAttribute().string(GLOBAL_ID_TYPE_NAME).withMaxLength(200).and();
-        foreignKey(tableName, GLOBAL_ID_OWNER_ID_FK, GLOBAL_ID_TABLE_NAME, GLOBAL_ID_PK, relationBuilder);
+        foreignKey(tableName, GLOBAL_ID_OWNER_ID_FK, getGlobalIdTableName(), GLOBAL_ID_PK, relationBuilder);
         relationBuilder.build();
 
         columnsIndex(tableName, schema, GLOBAL_ID_LOCAL_ID);
@@ -134,12 +139,12 @@ public class FixedSchemaFactory {
     private void foreignKey(String tableName, String fkColName, String targetTableName, String targetPkColName, RelationBuilder relationBuilder){
         relationBuilder
                 .withAttribute().longAttr(fkColName).and()
-                .foreignKey(tableName + "_" + fkColName).on(fkColName).references(targetTableName, targetPkColName).and();
+                .foreignKey(normaliseSchemaTableName(tableName) + "_" + fkColName).on(fkColName).references(targetTableName, targetPkColName).and();
     }
 
     private void columnsIndex(String tableName, Schema schema, String... colNames){
         String concatenatedColumnNames = StringUtils.concatenate('_', (Object[]) colNames);
-        String indexName = tableName + "_" + concatenatedColumnNames + "_idx";
+        String indexName = normaliseSchemaTableName(tableName) + "_" + concatenatedColumnNames + "_idx";
         if (dialect instanceof OracleDialect &&
             indexName.length() > ORACLE_MAX_NAME_LEN)
         {
@@ -154,6 +159,128 @@ public class FixedSchemaFactory {
     private void primaryKey(String pkColName, Schema schema, RelationBuilder relationBuilder) {
         relationBuilder.withAttribute().longAttr(pkColName).withAdditionalModifiers("AUTO_INCREMENT").notNull().and()
                 .primaryKey("jv_"+pkColName).using(pkColName).and();
-        schema.addSequence("jv_"+pkColName+"_seq").build();
+        schema.addSequence(getSequenceName(pkColName)).build();
+    }
+
+    /**
+     * Since table names might have a schema name with a '.' attached to them, we are normalising the name by replacing
+     * '.' with '_'. Example: schema1.table_name becomes schema1_table_name.
+     * @return
+     */
+    private String normaliseSchemaTableName(String schemaTableName) {
+        return schemaTableName.replace('.','_');
+    }
+
+    /**
+     * Sequences should be stored in the same Schema with their respective tables.
+     *
+     * @param pkColName
+     * @return
+     */
+    private String getSequenceName(String pkColName) {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return "jv_"+pkColName+"_seq";
+        }
+        else
+        {
+            return SCHEMA_NAME+".jv_"+pkColName+"_seq";
+        }
+    }
+
+    public static String getGlobalIdTableName()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return GLOBAL_ID_TABLE_NAME;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+GLOBAL_ID_TABLE_NAME;
+        }
+    }
+
+    public static String getGlobalIdPkSeq()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return GLOBAL_ID_PK_SEQ;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+GLOBAL_ID_PK_SEQ;
+        }
+    }
+
+    public static String getCommitTableName()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return COMMIT_TABLE_NAME;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+COMMIT_TABLE_NAME;
+        }
+    }
+
+    public static String getCommitPkSeq()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return COMMIT_PK_SEQ;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+COMMIT_PK_SEQ;
+        }
+    }
+
+    public static String getCommitPropertyTableName()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return COMMIT_PROPERTY_TABLE_NAME;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+COMMIT_PROPERTY_TABLE_NAME;
+        }
+    }
+
+    public static String getSnapshotTableName()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return SNAPSHOT_TABLE_NAME;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+SNAPSHOT_TABLE_NAME;
+        }
+    }
+
+    public static String getSnapshotTablePkSeq()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return SNAPSHOT_TABLE_PK_SEQ;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+SNAPSHOT_TABLE_PK_SEQ;
+        }
+    }
+
+    public static String getCdoClassTableName()
+    {
+        if (SCHEMA_NAME.isEmpty())
+        {
+            return CDO_CLASS_TABLE_NAME;
+        }
+        else
+        {
+            return SCHEMA_NAME+SCHEMA_TABLE_SEP+CDO_CLASS_TABLE_NAME;
+        }
     }
 }


### PR DESCRIPTION
added withSchema() to SqlRepositoryBuilder to enable users to create and use tables in a defined Schema.

As part of the change, the static table and sequence names in the FixedSchemaFactory class have been made private and access to them is made available through static getters (which check if a schema was defined).

The JaversSchemaManager has been modified to check for the javers tables if a schema has been defined.  If no schema has been defined, this resposibility to handed over to PolyJDBC.