### PR TITLE
Update QueryBuilder::withNewObjectChanges(boolean) method to use parameter

### DIFF
--- a/javers-core/src/main/java/org/javers/repository/jql/QueryBuilder.java
+++ b/javers-core/src/main/java/org/javers/repository/jql/QueryBuilder.java
@@ -161,7 +161,7 @@ public class QueryBuilder {
      * and initial property value on the right.
      */
     public QueryBuilder withNewObjectChanges(boolean newObjectChanges) {
-        queryParamsBuilder.newObjectChanges(true);
+        queryParamsBuilder.newObjectChanges(newObjectChanges);
         return this;
     }
 


### PR DESCRIPTION
It seems the parameter `withNewObjectChanges `was missed to pass to `queryParamsBuilder`.

```
    public QueryBuilder withNewObjectChanges(boolean newObjectChanges) {  // newObjectChanges not passed to queryParamsBuilder
        queryParamsBuilder.newObjectChanges(true);
        return this;
    }
```