### PR TITLE
Avoid nested DiffIgnored ValueObject being compare

### DIFF
--- a/javers-core/src/main/java/org/javers/core/json/JsonConverterBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/json/JsonConverterBuilder.java
@@ -3,6 +3,7 @@ package org.javers.core.json;
 import com.google.gson.*;
 import org.javers.common.validation.Validate;
 import org.javers.core.json.typeadapter.date.DateTypeCoreAdapters;
+import org.javers.core.metamodel.annotation.DiffIgnore;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -21,6 +22,7 @@ public class JsonConverterBuilder {
 
     public JsonConverterBuilder() {
         this.gsonBuilder = new GsonBuilder();
+        this.gsonBuilder.setExclusionStrategies(new SkipFieldExclusionStrategy());
     }
 
     /**
@@ -134,6 +136,17 @@ public class JsonConverterBuilder {
 
         registerNativeGsonSerializer(targetType, jsonSerializer);
         registerNativeGsonDeserializer(targetType, jsonDeserializer);
+    }
+
+    private static class SkipFieldExclusionStrategy implements ExclusionStrategy {
+
+        public boolean shouldSkipClass(Class<?> clazz) {
+            return clazz.getAnnotation(DiffIgnore.class) != null;
+        }
+
+        public boolean shouldSkipField(FieldAttributes field) {
+            return field.getAnnotation(DiffIgnore.class) != null;
+        }
     }
 
 }

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/CrossReferenceTest.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/CrossReferenceTest.groovy
@@ -1,0 +1,68 @@
+package org.javers.repository.mongo
+
+import com.github.fakemongo.Fongo
+import org.javers.core.JaversBuilder
+import org.javers.core.metamodel.clazz.EntityDefinition
+import org.javers.repository.mongo.model.CrossReferenceHost
+import org.javers.repository.mongo.model.CrossReferenceObjectA
+import org.javers.repository.mongo.model.CrossReferenceObjectB
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Decouple cross reference object by DiffIgnore
+ *
+ * @author hank cp
+ */
+class CrossReferenceTest extends Specification {
+
+    @Shared def mongoDb
+
+    def setup(){
+        mongoDb = new Fongo("myDb").getDatabase("test")
+    }
+
+    def "should throw StackOverflowError exception"() {
+        given:
+        def javers = JaversBuilder.javers()
+                .registerEntity(new EntityDefinition(CrossReferenceHost, "id"))
+                .registerJaversRepository(new MongoRepository(mongoDb))
+                .build()
+
+        when:
+        def host = new CrossReferenceHost()
+        host.id = 1;
+        host.a = new CrossReferenceObjectA()
+        host.a.bList = new ArrayList<>()
+        host.a.bList.add(new CrossReferenceObjectB(1, host.a))
+        host.a.bList.add(new CrossReferenceObjectB(2, host.a))
+        host.a.bList.add(new CrossReferenceObjectB(3, host.a))
+
+        javers.commit("author", host)
+
+        then:
+            thrown StackOverflowError
+    }
+
+    def "should not throw StackOverflow exception"() {
+        given:
+        def javers = JaversBuilder.javers()
+                .registerEntity(new EntityDefinition(CrossReferenceHost, "id"))
+                .registerJaversRepository(new MongoRepository(mongoDb))
+                .build()
+
+        when:
+        def host = new CrossReferenceHost()
+        host.id = 1;
+        host.a = new CrossReferenceObjectA()
+        host.a.bListIgnored = new ArrayList<>()
+        host.a.bListIgnored.add(new CrossReferenceObjectB(1, host.a))
+        host.a.bListIgnored.add(new CrossReferenceObjectB(2, host.a))
+        host.a.bListIgnored.add(new CrossReferenceObjectB(3, host.a))
+
+        def commit = javers.commit("author", host)
+
+        then:
+        commit != null
+    }
+}

--- a/javers-persistence-mongo/src/test/java/org/javers/repository/mongo/model/CrossReferenceHost.java
+++ b/javers-persistence-mongo/src/test/java/org/javers/repository/mongo/model/CrossReferenceHost.java
@@ -1,0 +1,15 @@
+package org.javers.repository.mongo.model;
+
+import javax.persistence.Id;
+
+/**
+ * @author hank cp
+ */
+public class CrossReferenceHost {
+
+    @Id
+    public long id;
+
+    public CrossReferenceObjectA a;
+
+}

--- a/javers-persistence-mongo/src/test/java/org/javers/repository/mongo/model/CrossReferenceObjectA.java
+++ b/javers-persistence-mongo/src/test/java/org/javers/repository/mongo/model/CrossReferenceObjectA.java
@@ -1,0 +1,22 @@
+package org.javers.repository.mongo.model;
+
+import org.javers.core.metamodel.annotation.DiffIgnore;
+import org.javers.core.metamodel.annotation.Value;
+
+import javax.persistence.OneToMany;
+import java.util.List;
+
+/**
+ * @author hank cp
+ */
+@Value
+public class CrossReferenceObjectA {
+
+    @OneToMany
+    public List<CrossReferenceObjectB> bList;
+
+    @OneToMany
+    @DiffIgnore
+    public List<CrossReferenceObjectB> bListIgnored;
+
+}

--- a/javers-persistence-mongo/src/test/java/org/javers/repository/mongo/model/CrossReferenceObjectB.java
+++ b/javers-persistence-mongo/src/test/java/org/javers/repository/mongo/model/CrossReferenceObjectB.java
@@ -1,0 +1,21 @@
+package org.javers.repository.mongo.model;
+
+import org.javers.core.metamodel.annotation.Value;
+
+/**
+ * @author hank cp
+ */
+@Value
+public class CrossReferenceObjectB {
+
+    public int value;
+
+    public CrossReferenceObjectA a;
+
+    public CrossReferenceObjectB() {}
+
+    public CrossReferenceObjectB(int value, CrossReferenceObjectA a) {
+        this.value = value;
+        this.a = a;
+    }
+}


### PR DESCRIPTION
Set gsonBuilder exclusionStrategies to avoid nested ValueObject circular reference.