### PR TITLE
448 add new annotation called @IgnoreDeclaredProperties

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/annotation/IgnoreDeclaredProperties.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/annotation/IgnoreDeclaredProperties.java
@@ -1,0 +1,26 @@
+package org.javers.core.metamodel.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ *
+ * Add {@link IgnoreDeclaredProperties} to classes to ignore all their properties.
+ * <br>
+ * <br>
+ * If a class is annotated with {@link IgnoreDeclaredProperties} and is part of an audited hierarchy,
+ * only the properties of the class are ignored, and JaVers will still track any other properties in the
+ * class hierarchy.
+ * By contrast, if a class is annotated with {@link DiffIgnore} JaVers will ignore all instances of
+ * that class.
+ * @see DiffIgnore
+ * @author Edward Mallia
+ */
+@Target({ TYPE})
+@Retention(RUNTIME)
+public @interface IgnoreDeclaredProperties
+{
+}

--- a/javers-core/src/main/java/org/javers/core/metamodel/scanner/BeanBasedPropertyScanner.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/scanner/BeanBasedPropertyScanner.java
@@ -1,7 +1,9 @@
 package org.javers.core.metamodel.scanner;
 
+import org.javers.common.reflection.JaversField;
 import org.javers.common.reflection.JaversMethod;
 import org.javers.common.reflection.ReflectionUtil;
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties;
 import org.javers.core.metamodel.property.Property;
 
 import java.util.ArrayList;
@@ -20,15 +22,28 @@ class BeanBasedPropertyScanner implements PropertyScanner {
 
     @Override
     public PropertyScan scan(Class<?> managedClass) {
-        List<JaversMethod> getters = ReflectionUtil.findAllPersistentGetters(managedClass);
-        List<Property> beanProperties = new ArrayList<>();
 
-        for (JaversMethod getter : getters) {
+        final IgnoreDeclaredProperties ignoreDeclaredPropertiesAnnotation = managedClass.getAnnotation(IgnoreDeclaredProperties.class);
 
-            boolean hasTransientAnn = getter.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
+        if (ignoreDeclaredPropertiesAnnotation != null) {
+            List<JaversField> fields = ReflectionUtil.getAllPersistentFields(managedClass);
+            List<Property> beanProperties = new ArrayList<>(fields.size());
 
-            beanProperties.add(new Property(getter, hasTransientAnn));
+            for (JaversField field : fields) {
+                beanProperties.add(new Property(field, true));
+            }
+            return new PropertyScan(beanProperties);
+
+        } else {
+            List<Property> beanProperties = new ArrayList<>();
+            List<JaversMethod> getters = ReflectionUtil.findAllPersistentGetters(managedClass);
+            for (JaversMethod getter : getters) {
+
+                boolean hasTransientAnn = getter.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
+                beanProperties.add(new Property(getter, hasTransientAnn));
+            }
+            return new PropertyScan(beanProperties);
         }
-        return new PropertyScan(beanProperties);
+
     }
 }

--- a/javers-core/src/main/java/org/javers/core/metamodel/scanner/FieldBasedPropertyScanner.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/scanner/FieldBasedPropertyScanner.java
@@ -2,6 +2,7 @@ package org.javers.core.metamodel.scanner;
 
 import org.javers.common.reflection.JaversField;
 import org.javers.common.reflection.ReflectionUtil;
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties;
 import org.javers.core.metamodel.property.Property;
 
 import java.util.ArrayList;
@@ -23,9 +24,17 @@ class FieldBasedPropertyScanner implements PropertyScanner {
         List<JaversField> fields = ReflectionUtil.getAllPersistentFields(managedClass);
         List<Property> propertyList = new ArrayList<>(fields.size());
 
-        for (JaversField field : fields) {
-            boolean hasTransientAnn = field.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
-            propertyList.add(new Property(field, hasTransientAnn));
+        final IgnoreDeclaredProperties ignoreDeclaredPropertiesAnnotation = managedClass.getAnnotation(IgnoreDeclaredProperties.class);
+
+        if (ignoreDeclaredPropertiesAnnotation != null) {
+            for (JaversField field : fields) {
+                propertyList.add(new Property(field, true));
+            }
+        } else {
+            for (JaversField field : fields) {
+                boolean hasTransientAnn = field.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
+                propertyList.add(new Property(field, hasTransientAnn));
+            }
         }
         return new PropertyScan(propertyList);
     }

--- a/javers-core/src/main/java/org/javers/core/metamodel/scanner/JaversAnnotationsNamesSpace.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/scanner/JaversAnnotationsNamesSpace.java
@@ -3,6 +3,7 @@ package org.javers.core.metamodel.scanner;
 import org.javers.common.collections.Sets;
 import org.javers.core.metamodel.annotation.*;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/ManagedClassFactory.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/ManagedClassFactory.java
@@ -6,6 +6,7 @@ import org.javers.common.exception.JaversException;
 import org.javers.common.exception.JaversExceptionCode;
 import org.javers.common.reflection.ReflectionUtil;
 import org.javers.core.metamodel.annotation.DiffIgnore;
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties;
 import org.javers.core.metamodel.clazz.ClientsClassDefinition;
 import org.javers.core.metamodel.property.Property;
 import org.javers.core.metamodel.scanner.ClassScan;
@@ -40,6 +41,12 @@ class ManagedClassFactory {
     }
 
     private List<Property> filterIgnoredType(List<Property> properties, final Class<?> currentClass){
+
+        IgnoreDeclaredProperties annotation = currentClass.getAnnotation(IgnoreDeclaredProperties.class);
+        if (annotation != null) {
+            return new ArrayList<>();
+        }
+
         return Lists.negativeFilter(properties, new Predicate<Property>() {
             public boolean apply(Property property) {
                 if (property.getRawType() == currentClass){

--- a/javers-core/src/test/groovy/org/javers/core/metamodel/scanner/PropertyScannerTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/metamodel/scanner/PropertyScannerTest.groovy
@@ -3,6 +3,7 @@ package org.javers.core.metamodel.scanner
 import com.google.gson.reflect.TypeToken
 import org.javers.core.metamodel.property.PropertyScannerEntity
 import org.javers.core.model.DummyAddress
+import org.javers.core.model.DummyIgnoredPropertiesType
 import org.javers.core.model.DummyUser
 import org.javers.core.model.DummyUserDetails
 import org.joda.time.LocalDateTime
@@ -88,6 +89,14 @@ abstract class PropertyScannerTest extends Specification {
 
         then:
         assertThat(properties).hasProperty("propertyWithDiffIgnoreAnn").isTransient()
+    }
+
+    def "should scan all properties of classes marked as @IgnoreAllProperties as transient"() {
+        when:
+        def properties = propertyScanner.scan(DummyIgnoredPropertiesType)
+
+        then:
+        assertThat(properties).hasProperty("propertyThatShouldBeIgnored").isTransient()
     }
 
     def "should scan set property"() {

--- a/javers-core/src/test/groovy/org/javers/core/model/DummyIgnoredPropertiesType.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/model/DummyIgnoredPropertiesType.groovy
@@ -1,0 +1,17 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties
+
+/**
+ * Created by Ian Agius
+ */
+@IgnoreDeclaredProperties
+class DummyIgnoredPropertiesType extends DummyUser{
+
+    int propertyThatShouldBeIgnored
+
+    static DummyIgnoredPropertiesType dummyIgnoredPropertiesType(String name, int propertyThatShouldBeIgnored) {
+        return new DummyIgnoredPropertiesType(name:name, propertyThatShouldBeIgnored:propertyThatShouldBeIgnored);
+    }
+
+}


### PR DESCRIPTION
This is our suggested solution to have @IgnoreAllProperties annotation that ignores all properties of the annotated class.
Tells us what you think.