### PR TITLE
448 Add @IgnoreDeclaredProperties annotation

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/annotation/IgnoreDeclaredProperties.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/annotation/IgnoreDeclaredProperties.java
@@ -1,0 +1,26 @@
+package org.javers.core.metamodel.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ *
+ * Add {@link IgnoreDeclaredProperties} to classes to ignore all their properties.
+ * <br>
+ * <br>
+ * If a class is annotated with {@link IgnoreDeclaredProperties} and is part of an audited hierarchy,
+ * only the properties of the class are ignored, and JaVers will still track any other properties in the
+ * class hierarchy.
+ * By contrast, if a class is annotated with {@link DiffIgnore} JaVers will ignore all instances of
+ * that class.
+ * @see DiffIgnore
+ * @author Edward Mallia
+ */
+@Target({ TYPE})
+@Retention(RUNTIME)
+public @interface IgnoreDeclaredProperties
+{
+}

--- a/javers-core/src/main/java/org/javers/core/metamodel/scanner/BeanBasedPropertyScanner.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/scanner/BeanBasedPropertyScanner.java
@@ -2,6 +2,7 @@ package org.javers.core.metamodel.scanner;
 
 import org.javers.common.reflection.JaversMethod;
 import org.javers.common.reflection.ReflectionUtil;
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties;
 import org.javers.core.metamodel.property.Property;
 
 import java.util.ArrayList;
@@ -20,14 +21,23 @@ class BeanBasedPropertyScanner implements PropertyScanner {
 
     @Override
     public PropertyScan scan(Class<?> managedClass) {
+        final IgnoreDeclaredProperties ignoreDeclaredPropertiesAnnotation = managedClass.getAnnotation(IgnoreDeclaredProperties.class);
         List<JaversMethod> getters = ReflectionUtil.findAllPersistentGetters(managedClass);
         List<Property> beanProperties = new ArrayList<>();
 
-        for (JaversMethod getter : getters) {
-            boolean hasTransientAnn = getter.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
-            boolean hasShallowReferenceAnn = getter.hasAnyAnnotation(annotationNamesProvider.getShallowReferenceAliases());
-            beanProperties.add(new Property(getter, hasTransientAnn, hasShallowReferenceAnn));
+        if (ignoreDeclaredPropertiesAnnotation != null) {
+            for (JaversMethod getter : getters) {
+                beanProperties.add(new Property(getter, true));
+            }
+        } else {
+            for (JaversMethod getter : getters) {
+                boolean hasTransientAnn = getter.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
+                boolean hasShallowReferenceAnn = getter.hasAnyAnnotation(annotationNamesProvider.getShallowReferenceAliases());
+                beanProperties.add(new Property(getter, hasTransientAnn, hasShallowReferenceAnn));
+            }
+
         }
         return new PropertyScan(beanProperties);
     }
+
 }

--- a/javers-core/src/main/java/org/javers/core/metamodel/scanner/FieldBasedPropertyScanner.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/scanner/FieldBasedPropertyScanner.java
@@ -2,6 +2,7 @@ package org.javers.core.metamodel.scanner;
 
 import org.javers.common.reflection.JaversField;
 import org.javers.common.reflection.ReflectionUtil;
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties;
 import org.javers.core.metamodel.property.Property;
 
 import java.util.ArrayList;
@@ -20,14 +21,22 @@ class FieldBasedPropertyScanner implements PropertyScanner {
 
     @Override
     public PropertyScan scan(Class<?> managedClass) {
+        final IgnoreDeclaredProperties ignoreDeclaredPropertiesAnnotation = managedClass.getAnnotation(IgnoreDeclaredProperties.class);
         List<JaversField> fields = ReflectionUtil.getAllPersistentFields(managedClass);
         List<Property> propertyList = new ArrayList<>(fields.size());
 
-        for (JaversField field : fields) {
-            boolean hasTransientAnn = field.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
-            boolean hasShallowReferenceAnn = field.hasAnyAnnotation(annotationNamesProvider.getShallowReferenceAliases());
-            propertyList.add(new Property(field, hasTransientAnn, hasShallowReferenceAnn));
+        if (ignoreDeclaredPropertiesAnnotation != null) {
+            for (JaversField field : fields) {
+                propertyList.add(new Property(field, true));
+            }
+        } else {
+            for (JaversField field : fields) {
+                boolean hasTransientAnn = field.hasAnyAnnotation(annotationNamesProvider.getTransientAliases());
+                boolean hasShallowReferenceAnn = field.hasAnyAnnotation(annotationNamesProvider.getShallowReferenceAliases());
+                propertyList.add(new Property(field, hasTransientAnn, hasShallowReferenceAnn));
+            }
         }
         return new PropertyScan(propertyList);
     }
+
 }

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/ManagedClassFactory.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/ManagedClassFactory.java
@@ -6,6 +6,7 @@ import org.javers.common.exception.JaversException;
 import org.javers.common.exception.JaversExceptionCode;
 import org.javers.common.reflection.ReflectionUtil;
 import org.javers.core.metamodel.annotation.DiffIgnore;
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties;
 import org.javers.core.metamodel.clazz.ClientsClassDefinition;
 import org.javers.core.metamodel.property.Property;
 import org.javers.core.metamodel.scanner.ClassScan;
@@ -40,6 +41,12 @@ class ManagedClassFactory {
     }
 
     private List<Property> filterIgnoredType(List<Property> properties, final Class<?> currentClass){
+
+        IgnoreDeclaredProperties annotation = currentClass.getAnnotation(IgnoreDeclaredProperties.class);
+        if (annotation != null) {
+            return new ArrayList<>();
+        }
+
         return Lists.negativeFilter(properties, new Predicate<Property>() {
             public boolean apply(Property property) {
                 if (property.getRawType() == currentClass){

--- a/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
@@ -1,7 +1,10 @@
 package org.javers.core
 
 import groovy.json.JsonSlurper
+import org.javers.core.diff.AbstractDiffTest
 import org.javers.core.diff.DiffAssert
+import org.javers.core.diff.GraphPair
+import org.javers.core.diff.appenders.NewObjectAppender
 import org.javers.core.diff.changetype.NewObject
 import org.javers.core.diff.changetype.PropertyChange
 import org.javers.core.diff.changetype.ReferenceChange
@@ -12,7 +15,6 @@ import org.javers.core.json.DummyPointNativeTypeAdapter
 import org.javers.core.metamodel.annotation.Id
 import org.javers.core.metamodel.property.Property
 import org.javers.core.model.*
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.javers.core.JaversBuilder.javers
@@ -21,13 +23,16 @@ import static org.javers.core.MappingStyle.FIELD
 import static org.javers.core.model.DummyUser.Sex.FEMALE
 import static org.javers.core.model.DummyUser.Sex.MALE
 import static org.javers.core.model.DummyUser.dummyUser
+import static org.javers.core.model.DummyIgnoredPropertiesType.dummyIgnoredPropertiesType;
 import static org.javers.core.model.DummyUserWithPoint.userWithPoint
 import static org.javers.repository.jql.InstanceIdDTO.instanceId
+
+import static org.javers.core.diff.ChangeAssert.assertThat
 
 /**
  * @author bartosz walacik
  */
-class JaversDiffE2ETest extends Specification {
+class JaversDiffE2ETest extends AbstractDiffTest {
 
     def "should extract Property from PropertyChange"(){
       given:
@@ -297,6 +302,35 @@ class JaversDiffE2ETest extends Specification {
 
         expect:
         javers.compare(left, right).changes.size() == 0
+    }
+
+    def "should ignore all properties of a class with @IgnoreAllProperties"(){
+        given:
+        def javers = javers().build()
+        def left =  new DummyIgnoredPropertiesType('name', 1, 1, 5)
+        def right = new DummyIgnoredPropertiesType('name', 2, 2, 10)
+
+        expect:
+        javers.compare(left, right).changes.size() == 0
+    }
+
+    def "should append one newobject with correct entity type, when it is annotated with @IgnoreAllProperties"() {
+
+        given:
+        def cdoRight = dummyIgnoredPropertiesType('nameChange', 10)
+        def left =  buildLiveGraph(dummyUser('name'))
+        def right = buildLiveGraph(cdoRight)
+
+        when:
+        def changes = new NewObjectAppender().getChangeSet(new GraphPair(left, right))
+
+        then:
+        changes.size() == 1
+        assertThat(changes[0])
+                .isNewObject()
+                .hasCdoId("nameChange")
+                .hasEntityTypeOf(DummyIgnoredPropertiesType)
+                .hasAffectedCdo(cdoRight)
     }
 
     class SetValueObject {

--- a/javers-core/src/test/groovy/org/javers/core/metamodel/scanner/PropertyScannerTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/metamodel/scanner/PropertyScannerTest.groovy
@@ -3,6 +3,7 @@ package org.javers.core.metamodel.scanner
 import com.google.gson.reflect.TypeToken
 import org.javers.core.metamodel.property.PropertyScannerEntity
 import org.javers.core.model.DummyAddress
+import org.javers.core.model.DummyIgnoredPropertiesType
 import org.javers.core.model.DummyUser
 import org.javers.core.model.DummyUserDetails
 import org.joda.time.LocalDateTime
@@ -88,6 +89,14 @@ abstract class PropertyScannerTest extends Specification {
 
         then:
         assertThat(properties).hasProperty("propertyWithDiffIgnoreAnn").isTransient()
+    }
+
+    def "should scan all properties of classes marked as @IgnoreAllProperties as transient"() {
+        when:
+        def properties = propertyScanner.scan(DummyIgnoredPropertiesType)
+
+        then:
+        assertThat(properties).hasProperty("propertyThatShouldBeIgnored").isTransient()
     }
 
     def "should scan set property"() {

--- a/javers-core/src/test/groovy/org/javers/core/model/DummyIgnoredPropertiesType.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/model/DummyIgnoredPropertiesType.groovy
@@ -1,0 +1,29 @@
+package org.javers.core.model
+
+import org.javers.core.metamodel.annotation.IgnoreDeclaredProperties
+
+/**
+ * Created by Ian Agius
+ */
+@IgnoreDeclaredProperties
+class DummyIgnoredPropertiesType extends DummyUser{
+
+    int propertyThatShouldBeIgnored
+
+    DummyIgnoredPropertiesType(String name, int propertyThatShouldBeIgnored) {
+        super(name)
+        this.propertyThatShouldBeIgnored = propertyThatShouldBeIgnored
+    }
+
+    DummyIgnoredPropertiesType(String name, int propertyWithTransientAnn, int propertyWithDiffIgnoreAnn, int propertyThatShouldBeIgnored) {
+        this.name = name
+        this.propertyWithTransientAnn = propertyWithTransientAnn
+        this.propertyWithDiffIgnoreAnn = propertyWithDiffIgnoreAnn
+        this.propertyThatShouldBeIgnored = propertyThatShouldBeIgnored
+    }
+
+    static DummyIgnoredPropertiesType dummyIgnoredPropertiesType(String name, int propertyThatShouldBeIgnored) {
+        return new DummyIgnoredPropertiesType(name, propertyThatShouldBeIgnored);
+    }
+
+}


### PR DESCRIPTION
Add @IgnoreDeclaredProperties to classes to ignore all their properties.
If a class is annotated with @IgnoreDeclaredProperties and is part of an audited hierarchy, only the properties of the class are ignored, and JaVers will still track any other properties in the class hierarchy.
By contrast, if a class is annotated with @DiffIgnore JaVers will ignore all instances of that class.
