### PR TITLE
fix type erasure issue with Bean MappingStyle

### DIFF
--- a/javers-core/src/main/java/org/javers/common/reflection/JaversMethodFactory.java
+++ b/javers-core/src/main/java/org/javers/common/reflection/JaversMethodFactory.java
@@ -32,6 +32,9 @@ class JaversMethodFactory {
         while (clazz != null) {
             context.addTypeSubstitutions(clazz);
             for (Method m : clazz.getDeclaredMethods()) {
+                if (m.isBridge()) {
+                    continue;
+                }
                 int methodKey = methodKey(m);
                 if (added.contains(methodKey)) {
                     // System.out.println("filtered inheritance duplicate" +m);

--- a/javers-core/src/test/groovy/org/javers/core/metamodel/type/TypeFactoryBeanIdTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/metamodel/type/TypeFactoryBeanIdTest.groovy
@@ -1,6 +1,8 @@
 package org.javers.core.metamodel.type
 
 import org.javers.core.MappingStyle
+import org.javers.core.metamodel.clazz.EntityDefinition
+import org.javers.core.model.Entity
 
 /**
  * @author bartosz walacik
@@ -9,5 +11,13 @@ class TypeFactoryBeanIdTest extends TypeFactoryIdTest {
 
     def setupSpec() {
         typeFactory = TypeFactoryTest.create(MappingStyle.BEAN)
+    }
+
+    def "should not fail for Entity annotated with @Id on an extended generic method"() {
+        when:
+        def entity = typeFactory.create(new EntityDefinition(Entity.class))
+
+        then:
+        entity.idProperty.name == 'id'
     }
 }

--- a/javers-core/src/test/java/org/javers/core/model/AbstractEntity.java
+++ b/javers-core/src/test/java/org/javers/core/model/AbstractEntity.java
@@ -1,0 +1,10 @@
+package org.javers.core.model;
+
+import java.io.Serializable;
+
+/**
+ * Created by Ian Agius
+ */
+public abstract class AbstractEntity<ID extends Serializable> {
+    public abstract ID getId();
+}

--- a/javers-core/src/test/java/org/javers/core/model/Entity.java
+++ b/javers-core/src/test/java/org/javers/core/model/Entity.java
@@ -1,0 +1,24 @@
+package org.javers.core.model;
+
+import org.javers.core.metamodel.annotation.Id;
+
+/**
+ * Created by Ian Agius
+ */
+public class Entity extends AbstractEntity<Long> {
+    private Long id;
+
+    public Entity(Long id) {
+        this.id = id;
+    }
+
+    @Id
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
The proposed solution is to ignore bridge methods in the method JaversMethodFactory.getAllMethods().
Two test models and 1 test to test this particular scenario has been added.