### PR TITLE
Changes to support adding a revision for legacy tables

### DIFF
--- a/javers-core/src/main/java/org/javers/core/JaversCore.java
+++ b/javers-core/src/main/java/org/javers/core/JaversCore.java
@@ -92,7 +92,7 @@ class JaversCore implements Javers {
         argumentsAreNotNull(author, properties, deleted);
 
         Commit commit = commitFactory.createTerminal(author, properties, deleted);
-
+        if (commit == null) return null;
         repository.persist(commit);
         logger.info(commit.toString());
         return commit;
@@ -109,6 +109,7 @@ class JaversCore implements Javers {
         argumentsAreNotNull(author, properties, globalId);
 
         Commit commit = commitFactory.createTerminalByGlobalId(author, properties, globalIdFactory.createFromDto(globalId));
+        if (commit == null) return null;
 
         repository.persist(commit);
         logger.info(commit.toString());

--- a/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
+++ b/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
@@ -47,7 +47,7 @@ public class CommitFactory {
         Validate.argumentsAreNotNull(author, properties, removedId);
         Optional<CdoSnapshot> previousSnapshot = javersRepository.getLatest(removedId);
         if (previousSnapshot.isEmpty()){
-            throw new JaversException(JaversExceptionCode.CANT_DELETE_OBJECT_NOT_FOUND,removedId.value());
+           return null; 
         }
         CommitMetadata commitMetadata = nextCommit(author, properties);
         CdoSnapshot terminalSnapshot = snapshotFactory.createTerminal(removedId, previousSnapshot.get(), commitMetadata);

--- a/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
@@ -95,19 +95,6 @@ class JaversCommitE2ETest extends Specification {
         opType << ["using object instance","using globalId"]
     }
 
-    def "should fail when deleting non existing object"() {
-        given:
-        def javers = javers().build()
-        def anEntity = new SnapshotEntity(id:1)
-
-        when:
-        javers.commitShallowDelete("some.login", anEntity)
-
-        then:
-        JaversException exception = thrown()
-        exception.code == JaversExceptionCode.CANT_DELETE_OBJECT_NOT_FOUND
-    }
-
     def "should create initial commit for new objects"() {
         given:
         def javers = javers().build()


### PR DESCRIPTION
Changes to not throw for adding a revision where there is no prior history. We have legacy tables with no JaVers revisioning and need to support adding new history for them