### PR TITLE
#532 possibility to clear SequenceAllocation cache

### DIFF
--- a/javers-persistence-sql/build.gradle
+++ b/javers-persistence-sql/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':javers-core')
-    compile 'org.polyjdbc:polyjdbc:0.6.5'
+    compile 'org.polyjdbc:polyjdbc:0.6.6'
     compile "com.google.guava:guava:$guavaVersion"
 
     testCompile project(path: ":javers-core", configuration: "testArtifacts")

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/JaversSqlRepository.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/JaversSqlRepository.java
@@ -138,6 +138,8 @@ public class JaversSqlRepository implements JaversRepository {
     }
 
     /**
+     * Clears the sequence allocation cache. It can be useful for testing.
+     * See https://github.com/javers/javers/issues/532
      * @since 3.1.1
      */
     public void evictSequenceAllocationCache() {

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/JaversSqlRepository.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/JaversSqlRepository.java
@@ -1,6 +1,5 @@
 package org.javers.repository.sql;
 
-import java.util.Optional;
 import org.javers.common.exception.JaversException;
 import org.javers.common.exception.JaversExceptionCode;
 import org.javers.core.commit.Commit;
@@ -18,13 +17,16 @@ import org.javers.repository.sql.repositories.CdoSnapshotRepository;
 import org.javers.repository.sql.repositories.CommitMetadataRepository;
 import org.javers.repository.sql.repositories.GlobalIdRepository;
 import org.javers.repository.sql.schema.JaversSchemaManager;
+import org.polyjdbc.core.PolyJDBC;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class JaversSqlRepository implements JaversRepository {
 
+    private final PolyJDBC polyJDBC;
     private final CommitMetadataRepository commitRepository;
     private final GlobalIdRepository globalIdRepository;
     private final CdoSnapshotRepository cdoSnapshotRepository;
@@ -32,7 +34,10 @@ public class JaversSqlRepository implements JaversRepository {
     private final JaversSchemaManager schemaManager;
     private final SqlRepositoryConfiguration sqlRepositoryConfiguration;
 
-    public JaversSqlRepository(CommitMetadataRepository commitRepository, GlobalIdRepository globalIdRepository, CdoSnapshotRepository cdoSnapshotRepository, CdoSnapshotFinder finder, JaversSchemaManager schemaManager, SqlRepositoryConfiguration sqlRepositoryConfiguration) {
+    public JaversSqlRepository(PolyJDBC polyJDBC, CommitMetadataRepository commitRepository, GlobalIdRepository globalIdRepository,
+                               CdoSnapshotRepository cdoSnapshotRepository, CdoSnapshotFinder finder, JaversSchemaManager schemaManager,
+                               SqlRepositoryConfiguration sqlRepositoryConfiguration) {
+        this.polyJDBC = polyJDBC;
         this.commitRepository = commitRepository;
         this.globalIdRepository = globalIdRepository;
         this.cdoSnapshotRepository = cdoSnapshotRepository;
@@ -130,5 +135,12 @@ public class JaversSqlRepository implements JaversRepository {
      */
     public SqlRepositoryConfiguration getConfiguration() {
         return sqlRepositoryConfiguration;
+    }
+
+    /**
+     * @since 3.1.1
+     */
+    public void evictSequenceAllocationCache() {
+        polyJDBC.resetKeyGeneratorCache();
     }
 }

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2ETest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2ETest.groovy
@@ -1,14 +1,14 @@
 package org.javers.repository.sql
 
 import org.javers.core.model.SnapshotEntity
-import org.javers.repository.jql.QueryBuilder
+
 import java.sql.Connection
 import java.sql.DriverManager
 
 class H2SqlRepositoryE2ETest extends JaversSqlRepositoryE2ETest {
 
     Connection createConnection() {
-        DriverManager.getConnection( "jdbc:h2:mem:test" )
+        DriverManager.getConnection("jdbc:h2:mem:test")
     }
 
     DialectName getDialect() {
@@ -17,5 +17,29 @@ class H2SqlRepositoryE2ETest extends JaversSqlRepositoryE2ETest {
 
     String getSchema() {
         return null
+    }
+
+    /**
+     * see https://github.com/javers/javers/issues/532
+     */
+    def "should evict sequence allocation cache"() {
+        given:
+        (1..50).each {
+            javers.commit("author", new SnapshotEntity(id: 1, intProperty: it))
+        }
+
+        when:
+        clearTables()
+        execute("alter sequence  ${schemaPrefix()}jv_commit_pk_seq restart with 1")
+        execute("alter sequence  ${schemaPrefix()}jv_global_id_pk_seq restart with 1")
+        execute("alter sequence  ${schemaPrefix()}jv_snapshot_pk_seq restart with 1")
+        def sqlRepository = (JaversSqlRepository) repository
+        sqlRepository.evictSequenceAllocationCache()
+        sqlRepository.evictCache()
+
+        then:
+        (1..150).each {
+            javers.commit("author", new SnapshotEntity(id: 1, intProperty: it))
+        }
     }
 }


### PR DESCRIPTION
Changes:
- PolyJDBC upgrated to 0.6.6
- Exposed JaversSqlRepository as an Spring Bean

With the new method in JaversRepository, `JaversSqlRepository.evictCache()` can be misleading. I am wondering if we can rename it to something like `JaversSqlRepository.evictGlobalIdCache()`.