### PR TITLE
Javers uses deprecated type TEXT for mssql for Snapshot_State and Snapshot_Changed fields

### DIFF
--- a/javers-persistence-sql/build.gradle
+++ b/javers-persistence-sql/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':javers-core')
-    compile 'org.polyjdbc:polyjdbc:0.7.0'
+    compile 'org.polyjdbc:polyjdbc:0.7.1'
     compile "com.google.guava:guava:$guavaVersion"
 
     testCompile project(path: ":javers-core", configuration: "testArtifacts")
@@ -14,6 +14,7 @@ dependencies {
     testCompile 'mysql:mysql-connector-java:5.1.36'
     testCompile 'org.codehaus.gpars:gpars:1.2.1'
     testCompile "joda-time:joda-time:$jodaVersion"
+    testCompile group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '6.1.0.jre8'
 
 }
 

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
@@ -44,6 +44,10 @@ public class JaversSchemaManager extends SchemaNameAware {
 
         alterCommitIdColumnIfNeeded(); // JaVers 2.5 to 2.6 schema migration
 
+        if(this.dialect instanceof MsSqlDialect) {
+            alterMssqlTextColumns();
+        }
+
         TheCloser.close(schemaManager, schemaInspector);
     }
 
@@ -71,6 +75,14 @@ public class JaversSchemaManager extends SchemaNameAware {
                 handleUnsupportedDialect();
             }
         }
+    }
+
+    /**
+     * This method is needed for upgrading TEXT columns to VARCHAR(MAX) since TEXT is deprecated.
+     */
+    private void alterMssqlTextColumns() {
+        executeSQL("ALTER TABLE " + getSnapshotTableNameWithSchema() + " ALTER COLUMN state VARCHAR(MAX)");
+        executeSQL("ALTER TABLE " + getSnapshotTableNameWithSchema() + " ALTER COLUMN changed_properties VARCHAR(MAX)");
     }
 
     private void handleUnsupportedDialect() {


### PR DESCRIPTION
- Adding alter statement for mysql test text -> varchar(max) conversion.

- Setting gradle to pull new version of polyjdbc

- Adding mssql driver for testing  (unsure if this should be committed but I couldn't test without it, intellij was saying that I needed a driver.)

Note: I ran the tests with the build and the mssql integration tests and everything came up green 😄 