### PR TITLE
#605 Add List compare Algorithm SET.

### DIFF
--- a/javers-core/src/main/java/org/javers/core/diff/ListCompareAlgorithm.java
+++ b/javers-core/src/main/java/org/javers/core/diff/ListCompareAlgorithm.java
@@ -1,6 +1,7 @@
 package org.javers.core.diff;
 
 import org.javers.core.diff.appenders.CorePropertyChangeAppender;
+import org.javers.core.diff.appenders.SetListChangeAppender;
 import org.javers.core.diff.appenders.SimpleListChangeAppender;
 import org.javers.core.diff.appenders.levenshtein.LevenshteinListChangeAppender;
 import org.javers.core.diff.changetype.container.ListChange;
@@ -8,7 +9,8 @@ import org.javers.core.diff.changetype.container.ListChange;
 public enum ListCompareAlgorithm {
 
     SIMPLE(SimpleListChangeAppender.class),
-    LEVENSHTEIN_DISTANCE(LevenshteinListChangeAppender.class);
+    LEVENSHTEIN_DISTANCE(LevenshteinListChangeAppender.class),
+    SET(SetListChangeAppender.class);
 
     private final Class<? extends CorePropertyChangeAppender<ListChange>> listChangeAppender;
 

--- a/javers-core/src/main/java/org/javers/core/diff/appenders/SetChangeAppender.java
+++ b/javers-core/src/main/java/org/javers/core/diff/appenders/SetChangeAppender.java
@@ -36,7 +36,7 @@ class SetChangeAppender extends CorePropertyChangeAppender<SetChange> {
         return propertyType instanceof SetType;
     }
 
-    private List<ContainerElementChange> calculateEntryChanges(SetType setType, Set leftRawSet, Set rightRawSet, OwnerContext owner) {
+    List<ContainerElementChange> calculateEntryChanges(SetType setType, Set leftRawSet, Set rightRawSet, OwnerContext owner) {
 
         JaversType itemType = typeMapper.getJaversType(setType.getItemType());
         DehydrateContainerFunction dehydrateFunction = new DehydrateContainerFunction(itemType, globalIdFactory);

--- a/javers-core/src/main/java/org/javers/core/diff/appenders/SetListChangeAppender.java
+++ b/javers-core/src/main/java/org/javers/core/diff/appenders/SetListChangeAppender.java
@@ -1,0 +1,51 @@
+package org.javers.core.diff.appenders;
+
+import org.javers.core.diff.NodePair;
+import org.javers.core.diff.changetype.container.ContainerElementChange;
+import org.javers.core.diff.changetype.container.ListChange;
+import org.javers.core.metamodel.object.OwnerContext;
+import org.javers.core.metamodel.object.PropertyOwnerContext;
+import org.javers.core.metamodel.type.*;
+
+import java.util.List;
+
+import static org.javers.common.collections.Sets.asSet;
+
+/**
+ * @author Sergey Kobyshev
+ */
+public class SetListChangeAppender extends CorePropertyChangeAppender<ListChange> {
+
+    private final SetChangeAppender setChangeAppender;
+    private final TypeMapper typeMapper;
+
+    SetListChangeAppender(SetChangeAppender setChangeAppender, TypeMapper typeMapper) {
+        this.setChangeAppender = setChangeAppender;
+        this.typeMapper = typeMapper;
+    }
+
+    @Override
+    public boolean supports(JaversType propertyType) {
+        return propertyType instanceof ListType;
+    }
+
+    @Override
+    public ListChange calculateChanges(final NodePair pair, final JaversProperty property) {
+        List leftList = (List) pair.getLeftPropertyValue(property);
+        List rightList = (List) pair.getRightPropertyValue(property);
+
+        ListType listType = ((JaversProperty) property).getType();
+        OwnerContext owner = new PropertyOwnerContext(pair.getGlobalId(), property.getName());
+        SetType setType = typeMapper.getSetType(listType);
+
+        List<ContainerElementChange> entryChanges =
+                setChangeAppender.calculateEntryChanges(setType, leftList == null ? null : asSet(leftList), rightList == null ? null : asSet(rightList), owner);
+
+        if (!entryChanges.isEmpty()) {
+            renderNotParametrizedWarningIfNeeded(setType.getItemType(), "item", "Set", property);
+            return new ListChange(pair.getGlobalId(), property.getName(), entryChanges);
+        } else {
+            return null;
+        }
+    }
+}

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/TypeMapper.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/TypeMapper.java
@@ -89,6 +89,13 @@ public class TypeMapper {
     }
 
     /**
+     * only for change appenders
+     */
+    public SetType getSetType(ContainerType containerType){
+        return new SetType(containerType.getItemType());
+    }
+
+    /**
      * is Set, List or Array of ManagedClasses
      */
     public boolean isContainerOfManagedTypes(JaversType javersType){

--- a/javers-core/src/test/groovy/org/javers/core/diff/appenders/AbstractDiffAppendersTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/diff/appenders/AbstractDiffAppendersTest.groovy
@@ -31,4 +31,8 @@ abstract class AbstractDiffAppendersTest extends AbstractDiffTest {
     SetChangeAppender setChangeAppender() {
         new SetChangeAppender(javers.typeMapper, javers.globalIdFactory)
     }
+
+    SetListChangeAppender setListChangeAppender() {
+        new SetListChangeAppender(setChangeAppender(), javers.typeMapper)
+    }
 }

--- a/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetAppenderTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetAppenderTest.groovy
@@ -1,0 +1,104 @@
+package org.javers.core.diff.appenders
+
+import org.javers.core.diff.RealNodePair
+import org.javers.core.model.DummyUser
+import org.javers.core.model.SnapshotEntity
+import spock.lang.Shared
+import spock.lang.Unroll
+
+import java.time.LocalDate
+
+import static org.javers.core.diff.appenders.ContainerChangeAssert.getAssertThat
+
+/**
+ * @author pawel szymczyk
+ */
+abstract class SetAppenderTest extends AbstractDiffAppendersTest {
+
+    @Shared
+    CorePropertyChangeAppender propertyChangeAppender
+    @Shared
+    String commonFieldName
+    @Shared
+    String dateFieldName
+
+    @Unroll
+    def "should append #changesCount changes when left field is #leftField and right field is #rightField"() {
+
+        when:
+        def leftNode = buildGraph(new DummyUser(name: 'name', "$commonFieldName": leftField))
+        def rightNode = buildGraph(new DummyUser(name: 'name', "$commonFieldName": rightField))
+
+        def change = propertyChangeAppender.calculateChanges(
+                new RealNodePair(leftNode, rightNode), getProperty(DummyUser, commonFieldName))
+
+        then:
+        change.changes.size() == changesCount
+        change.changes.each {
+            assert it.index == null
+        }
+
+        where:
+        leftField            | rightField           || changesCount
+        null                 | ["1", "2"]           || 2
+        []                   | ["1", "2"]           || 2
+        ["1", "2"]           | ["1", "2", "3", "4"] || 2
+        ["1", "2"]           | ["2", "1", "3"]      || 1
+        ["1", "2"]           | []                   || 2
+        ["1", "2", "3", "4"] | ["1"]                || 3
+        ["2", "1", "3"]      | ["1", "2"]           || 1
+    }
+
+    @Unroll
+    def "should not append changes when left field #leftField and right field #rightField are equal"() {
+
+        when:
+        def leftNode = buildGraph(new DummyUser(name: 'name', "$commonFieldName": leftField))
+        def rightNode = buildGraph(new DummyUser(name: 'name', "$commonFieldName": rightField))
+
+        def change = propertyChangeAppender.calculateChanges(
+                new RealNodePair(leftNode, rightNode), getProperty(DummyUser, commonFieldName))
+
+        then:
+        change == null
+
+        where:
+        leftField  | rightField
+        []         | []
+        ["1", "2"] | ["1", "2"]
+        ["1", "2"] | ["2", "1"]
+    }
+
+    def "should append ValueAdded in field of Values"() {
+        given:
+        def leftCdo = new SnapshotEntity("$dateFieldName": [new LocalDate(2001, 1, 1)])
+        def rightCdo = new SnapshotEntity("$dateFieldName": [new LocalDate(2001, 5, 5), new LocalDate(2001, 1, 1)])
+
+        when:
+        def change = propertyChangeAppender
+                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, dateFieldName))
+
+        then:
+        assertThat(change)
+                .hasSize(1)
+                .hasValueAdded(new LocalDate(2001, 5, 5))
+
+    }
+
+    def "should append ValueRemoved in field of Values"() {
+        given:
+        def leftCdo = new SnapshotEntity("$dateFieldName": [new LocalDate(2001, 5, 5), new LocalDate(2001, 1, 1)])
+        def rightCdo = new SnapshotEntity("$dateFieldName": [new LocalDate(2001, 1, 1)])
+
+        when:
+        def change = propertyChangeAppender
+                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, dateFieldName))
+
+        then:
+        assertThat(change)
+                .hasSize(1)
+                .hasValueRemoved(new LocalDate(2001, 5, 5))
+
+    }
+
+}

--- a/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetChangeAppenderTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetChangeAppenderTest.groovy
@@ -1,96 +1,12 @@
 package org.javers.core.diff.appenders
-
-import org.javers.core.diff.RealNodePair
-import org.javers.core.model.DummyUser
-import org.javers.core.model.SnapshotEntity
-import java.time.LocalDate
-import spock.lang.Unroll
-
-import static org.javers.core.diff.appenders.ContainerChangeAssert.getAssertThat
-import static org.javers.core.model.DummyUser.dummyUser
-
 /**
- * @author pawel szymczyk
+ * @author Sergey Kobyshev
  */
-class SetChangeAppenderTest extends AbstractDiffAppendersTest {
+class SetChangeAppenderTest extends SetAppenderTest {
 
-    @Unroll
-    def "should append #changesCount changes when left set is #leftSet and right set is #rightSet"() {
-
-        when:
-        def leftNode = buildGraph(dummyUser().withStringsSet(leftSet as Set))
-        def rightNode = buildGraph(dummyUser().withStringsSet(rightSet as Set))
-
-        def change = setChangeAppender().calculateChanges(
-                new RealNodePair(leftNode, rightNode), getProperty(DummyUser, "stringSet"))
-
-        then:
-        change.changes.size() == changesCount
-        change.changes.each {
-            assert it.index == null
-        }
-
-        where:
-        leftSet              | rightSet             || changesCount
-        null                 | ["1", "2"]           || 2
-        []                   | ["1", "2"]           || 2
-        ["1", "2"]           | ["1", "2", "3", "4"] || 2
-        ["1", "2"]           | ["2", "1", "3"]      || 1
-        ["1", "2"]           | []                   || 2
-        ["1", "2", "3", "4"] | ["1"]                || 3
-        ["2", "1", "3"]      | ["1", "2"]           || 1
+    def setupSpec() {
+        propertyChangeAppender = setChangeAppender()
+        commonFieldName = "stringSet"
+        dateFieldName = "setOfDates"
     }
-
-    @Unroll
-    def "should not append changes when left set #leftSet and right set #rightSet are equal"() {
-
-        when:
-        def leftNode = buildGraph(dummyUser().withStringsSet(leftSet as Set))
-        def rightNode = buildGraph(dummyUser().withStringsSet(rightSet as Set))
-
-        def change = setChangeAppender().calculateChanges(
-                new RealNodePair(leftNode, rightNode), getProperty(DummyUser, "stringSet"))
-
-        then:
-        change == null
-
-        where:
-        leftSet        | rightSet
-        []             | []
-        ["1", "2"]     | ["1", "2"]
-        ["1", "2"]     | ["2", "1"]
-    }
-
-    def "should append ValueAdded in Set of Values"() {
-        given:
-        def leftCdo =  new SnapshotEntity(setOfDates: [new LocalDate(2001,1,1)])
-        def rightCdo = new SnapshotEntity(setOfDates: [new LocalDate(2001,5,5), new LocalDate(2001,1,1)])
-
-        when:
-        def change = setChangeAppender()
-                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, "setOfDates"))
-
-        then:
-        assertThat(change)
-                .hasSize(1)
-                .hasValueAdded(new LocalDate(2001,5,5))
-
-    }
-
-    def "should append ValueRemoved in Set of Values"() {
-        given:
-        def leftCdo =  new SnapshotEntity(setOfDates: [new LocalDate(2001,5,5), new LocalDate(2001,1,1)])
-        def rightCdo = new SnapshotEntity(setOfDates: [new LocalDate(2001,1,1)])
-
-        when:
-        def change = setChangeAppender()
-                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, "setOfDates"))
-
-        then:
-        assertThat(change)
-                .hasSize(1)
-                .hasValueRemoved(new LocalDate(2001,5,5))
-
-    }
-
 }

--- a/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetListChangeAppenderTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetListChangeAppenderTest.groovy
@@ -1,96 +1,13 @@
 package org.javers.core.diff.appenders
-
-import org.javers.core.model.DummyUser
-import org.javers.core.model.SnapshotEntity
-import spock.lang.Unroll
-
-import java.time.LocalDate
-
-import static org.javers.core.diff.appenders.ContainerChangeAssert.getAssertThat
-import static org.javers.core.model.DummyUser.dummyUser
-
 /**
  * @author Sergey Kobyshev
  */
-class SetListChangeAppenderTest extends AbstractDiffAppendersTest {
+class SetListChangeAppenderTest extends SetAppenderTest {
 
-    @Unroll
-    def "should append #changesCount changes when left list is #leftList and right list is #rightList"() {
-
-        when:
-        def leftNode =  dummyUser().withIntegerList(leftList)
-        def rightNode = dummyUser().withIntegerList(rightList)
-
-        def change = setListChangeAppender().calculateChanges(
-                realNodePair(leftNode, rightNode), getProperty(DummyUser, "integerList"))
-
-        then:
-        change.changes.size() == changesCount
-        change.changes.each {
-            assert it.index == null
-        }
-
-        where:
-        leftList             | rightList            || changesCount
-        null                 | [1, 2]               || 2
-        []                   | [1, 2]               || 2
-        [1, 2]               | [1, 2, 3, 4]         || 2
-        [1, 2]               | [2, 1, 3]            || 1
-        [1, 2]               | []                   || 2
-        [1, 2, 3, 4]         | [1]                  || 3
-        [2, 1, 3]            | [1, 2]               || 1
-    }
-
-    @Unroll
-    def "should not append changes when left list #leftList and right list #rightList are equal"() {
-
-        when:
-        def leftNode = dummyUser().withIntegerList(leftList)
-        def rightNode = dummyUser().withIntegerList(rightList)
-
-        def change = setListChangeAppender().calculateChanges(
-                realNodePair(leftNode, rightNode), getProperty(DummyUser, "integerList"))
-
-        then:
-        change == null
-
-        where:
-        leftList       | rightList
-        []             | []
-        [1, 2]         | [1, 2]
-        [1, 2]         | [2, 1]
-    }
-
-    def "should append ValueAdded in List of Values"() {
-        given:
-        def leftCdo =  new SnapshotEntity(listOfDates: [new LocalDate(2001,1,1)])
-        def rightCdo = new SnapshotEntity(listOfDates: [new LocalDate(2001,5,5), new LocalDate(2001,1,1)])
-
-        when:
-        def change = setListChangeAppender()
-                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, "listOfDates"))
-
-        then:
-        assertThat(change)
-                .hasSize(1)
-                .hasValueAdded(new LocalDate(2001,5,5))
-
-    }
-
-    def "should append ValueRemoved in List of Values"() {
-        given:
-        def leftCdo =  new SnapshotEntity(listOfDates: [new LocalDate(2001,5,5), new LocalDate(2001,1,1)])
-        def rightCdo = new SnapshotEntity(listOfDates: [new LocalDate(2001,1,1)])
-
-        when:
-        def change = setListChangeAppender()
-                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, "listOfDates"))
-
-        then:
-        assertThat(change)
-                .hasSize(1)
-                .hasValueRemoved(new LocalDate(2001,5,5))
-
+    def setupSpec() {
+        propertyChangeAppender = setListChangeAppender()
+        commonFieldName = "stringList"
+        dateFieldName = "listOfDates"
     }
 
 }

--- a/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetListChangeAppenderTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/diff/appenders/SetListChangeAppenderTest.groovy
@@ -1,0 +1,96 @@
+package org.javers.core.diff.appenders
+
+import org.javers.core.model.DummyUser
+import org.javers.core.model.SnapshotEntity
+import spock.lang.Unroll
+
+import java.time.LocalDate
+
+import static org.javers.core.diff.appenders.ContainerChangeAssert.getAssertThat
+import static org.javers.core.model.DummyUser.dummyUser
+
+/**
+ * @author Sergey Kobyshev
+ */
+class SetListChangeAppenderTest extends AbstractDiffAppendersTest {
+
+    @Unroll
+    def "should append #changesCount changes when left list is #leftList and right list is #rightList"() {
+
+        when:
+        def leftNode =  dummyUser().withIntegerList(leftList)
+        def rightNode = dummyUser().withIntegerList(rightList)
+
+        def change = setListChangeAppender().calculateChanges(
+                realNodePair(leftNode, rightNode), getProperty(DummyUser, "integerList"))
+
+        then:
+        change.changes.size() == changesCount
+        change.changes.each {
+            assert it.index == null
+        }
+
+        where:
+        leftList             | rightList            || changesCount
+        null                 | [1, 2]               || 2
+        []                   | [1, 2]               || 2
+        [1, 2]               | [1, 2, 3, 4]         || 2
+        [1, 2]               | [2, 1, 3]            || 1
+        [1, 2]               | []                   || 2
+        [1, 2, 3, 4]         | [1]                  || 3
+        [2, 1, 3]            | [1, 2]               || 1
+    }
+
+    @Unroll
+    def "should not append changes when left list #leftList and right list #rightList are equal"() {
+
+        when:
+        def leftNode = dummyUser().withIntegerList(leftList)
+        def rightNode = dummyUser().withIntegerList(rightList)
+
+        def change = setListChangeAppender().calculateChanges(
+                realNodePair(leftNode, rightNode), getProperty(DummyUser, "integerList"))
+
+        then:
+        change == null
+
+        where:
+        leftList       | rightList
+        []             | []
+        [1, 2]         | [1, 2]
+        [1, 2]         | [2, 1]
+    }
+
+    def "should append ValueAdded in List of Values"() {
+        given:
+        def leftCdo =  new SnapshotEntity(listOfDates: [new LocalDate(2001,1,1)])
+        def rightCdo = new SnapshotEntity(listOfDates: [new LocalDate(2001,5,5), new LocalDate(2001,1,1)])
+
+        when:
+        def change = setListChangeAppender()
+                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, "listOfDates"))
+
+        then:
+        assertThat(change)
+                .hasSize(1)
+                .hasValueAdded(new LocalDate(2001,5,5))
+
+    }
+
+    def "should append ValueRemoved in List of Values"() {
+        given:
+        def leftCdo =  new SnapshotEntity(listOfDates: [new LocalDate(2001,5,5), new LocalDate(2001,1,1)])
+        def rightCdo = new SnapshotEntity(listOfDates: [new LocalDate(2001,1,1)])
+
+        when:
+        def change = setListChangeAppender()
+                .calculateChanges(realNodePair(leftCdo, rightCdo), getProperty(SnapshotEntity, "listOfDates"))
+
+        then:
+        assertThat(change)
+                .hasSize(1)
+                .hasValueRemoved(new LocalDate(2001,5,5))
+
+    }
+
+}

--- a/javers-core/src/test/groovy/org/javers/core/model/DummyUser.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/model/DummyUser.groovy
@@ -38,6 +38,7 @@ class DummyUser extends AbstractDummyUser {
 
     //collections
     Set<String> stringSet
+    List<String> stringList
     List<Integer> integerList
     Map<String, LocalDateTime> primitiveMap
     Map<String, LocalDateTime> valueMap


### PR DESCRIPTION
Add new compare Algorithm to be able compare lists like a sets (ignoring ordering).
For now, If we want to compare collection without ordering, we should to use sets.
In case, when we need to ignore ordering and we can not to change existing lists Objects to sets we have some troubles. 
We can not to change our model and use Sets.