### PR TITLE
Adding support for Entity Type as Id of another Entity

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/type/EntityType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/EntityType.java
@@ -1,13 +1,14 @@
 package org.javers.core.metamodel.type;
 
-import java.util.Optional;
 import org.javers.common.exception.JaversException;
 import org.javers.common.exception.JaversExceptionCode;
 import org.javers.common.string.PrettyPrintBuilder;
 import org.javers.common.string.ToStringBuilder;
 import org.javers.common.validation.Validate;
 import org.javers.core.metamodel.object.InstanceId;
+
 import java.lang.reflect.Type;
+import java.util.Optional;
 
 /**
  * Entity class in client's domain model.
@@ -105,8 +106,24 @@ public class EntityType extends ManagedType {
     }
 
     private String localIdAsString(Object localId) {
-        PrimitiveOrValueType idPropertyType = getIdProperty().getType();
-        return idPropertyType.smartToString(localId);
+        PrimitiveOrValueType idPropertyType = getIdPropertyType();
+        return idPropertyType.smartToString(getIdValue(localId));
+    }
+
+    private Object getIdValue(Object localId) {
+        JaversType type = getIdProperty().getType();
+        if(type instanceof EntityType) {
+            return ((EntityType) type).getIdOf(localId);
+        }
+        return localId;
+    }
+
+    private PrimitiveOrValueType getIdPropertyType() {
+        JaversType type = getIdProperty().getType();
+        while(type instanceof EntityType) {
+            type = ((EntityType) type).getIdProperty().getType();
+        }
+        return (PrimitiveOrValueType) type;
     }
 
     @Override

--- a/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
@@ -114,6 +114,45 @@ class JaversDiffE2ETest extends AbstractDiffTest {
         diff.changes.get(0).affectedGlobalId.value() == DummyCompositePoint.class.name+"/(1,2)"
     }
 
+    class DummyWithEntityId {
+        @Id DummyEntityAsId dummyEntityAsId
+        int value
+    }
+
+    class DummyEntityAsId {
+        @Id
+        int id
+        int value
+        String name
+        int other
+
+        boolean equals(o) {
+            DummyEntityAsId that = (DummyEntityAsId) o
+            if (id != that.id) {
+                return false
+            }
+            return true
+        }
+
+        int hashCode() {
+            return id
+        }
+    }
+
+    def "should use toString of Id when an Entity was used as Id"(){
+        given:
+        def javers = javers().registerEntity(DummyEntityAsId.class).build()
+        def left  = new DummyWithEntityId(dummyEntityAsId: new DummyEntityAsId(id: 1, value:5, name: "josh", other: 3), value:5)
+        def right = new DummyWithEntityId(dummyEntityAsId: new DummyEntityAsId(id: 1, value:5, name: "josh", other: 3), value:6)
+
+        when:
+        def diff = javers.compare(left,right)
+
+        then:
+        DiffAssert.assertThat(diff).hasChanges(1).hasValueChangeAt("value",5,6)
+        diff.changes.get(0).affectedGlobalId.value() == DummyCompositePoint.class.name+"/1"
+    }
+
     def "should create NewObject for all nodes in initial diff"() {
         given:
         def javers = JaversTestBuilder.newInstance()

--- a/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
@@ -150,7 +150,7 @@ class JaversDiffE2ETest extends AbstractDiffTest {
 
         then:
         DiffAssert.assertThat(diff).hasChanges(1).hasValueChangeAt("value",5,6)
-        diff.changes.get(0).affectedGlobalId.value() == DummyCompositePoint.class.name+"/1"
+        diff.changes.get(0).affectedGlobalId.value() == DummyWithEntityId.class.name+"/1"
     }
 
     def "should create NewObject for all nodes in initial diff"() {


### PR DESCRIPTION
When I try to use an Entity as Id of another Entity I got "java.lang.ClassCastException: org.javers.core.metamodel.type.EntityType cannot be cast to org.javers.core.metamodel.type.PrimitiveOrValueType"

The alteration that I need is relatively simple to make Javers accept this condition.