### PR TITLE
enhancement for spring 2.x

### DIFF
--- a/javers-spring-jpa/src/main/java/org/javers/spring/auditable/aspect/springdatajpa/JaversSpringDataJpaAuditableRepositoryAspect.java
+++ b/javers-spring-jpa/src/main/java/org/javers/spring/auditable/aspect/springdatajpa/JaversSpringDataJpaAuditableRepositoryAspect.java
@@ -24,6 +24,11 @@ public class JaversSpringDataJpaAuditableRepositoryAspect extends AbstractSpring
         onDelete(pjp);
     }
 
+    @AfterReturning("execution(public * deleteById(..)) && this(org.springframework.data.repository.CrudRepository)")
+    public void onDeleteByIdExecuted(JoinPoint pjp) {
+        onDelete(pjp);
+    }
+
     @AfterReturning("execution(public * deleteAll(..)) && this(org.springframework.data.repository.CrudRepository)")
     public void onDeleteAllExecuted(JoinPoint jp) {
         onDelete(jp);

--- a/javers-spring/src/main/java/org/javers/spring/auditable/aspect/springdata/JaversSpringDataAuditableRepositoryAspect.java
+++ b/javers-spring/src/main/java/org/javers/spring/auditable/aspect/springdata/JaversSpringDataAuditableRepositoryAspect.java
@@ -27,6 +27,11 @@ public class JaversSpringDataAuditableRepositoryAspect extends AbstractSpringAud
         onDelete(pjp);
     }
 
+    @AfterReturning("execution(public * deleteById(..)) && this(org.springframework.data.repository.CrudRepository)")
+    public void onDeleteByIdExecuted(JoinPoint pjp) {
+        onDelete(pjp);
+    }
+
     @AfterReturning("execution(public * deleteAll(..)) && this(org.springframework.data.repository.CrudRepository)")
     public void onDeleteAllExecuted(JoinPoint pjp) {
         onDelete(pjp);


### PR DESCRIPTION
Fix issue with the spring boot 2.x. 

The `deleteById` has been introduced in the [spring data common: 2.0.0.M3](https://github.com/spring-projects/spring-data-commons/blob/2.0.0.M3/src/main/java/org/springframework/data/repository/CrudRepository.java)

related to the #677 
