### PR TITLE
Commit.commitDateInstant

### DIFF
--- a/javers-core/src/main/java/org/javers/common/date/DateProvider.java
+++ b/javers-core/src/main/java/org/javers/common/date/DateProvider.java
@@ -1,7 +1,11 @@
 package org.javers.common.date;
 
-import java.time.LocalDateTime;
+import org.javers.core.commit.CommitMetadata;
+import java.time.ZonedDateTime;
 
+/**
+ * Date provider for {@link CommitMetadata#getCommitDate()}
+ */
 public interface DateProvider {
-    LocalDateTime now();
+    ZonedDateTime now();
 }

--- a/javers-core/src/main/java/org/javers/common/date/DefaultDateProvider.java
+++ b/javers-core/src/main/java/org/javers/common/date/DefaultDateProvider.java
@@ -1,11 +1,11 @@
 package org.javers.common.date;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class DefaultDateProvider implements DateProvider {
 
     @Override
-    public LocalDateTime now() {
-        return LocalDateTime.now();
+    public ZonedDateTime now() {
+        return ZonedDateTime.now();
     }
 }

--- a/javers-core/src/main/java/org/javers/core/CommitIdGenerator.java
+++ b/javers-core/src/main/java/org/javers/core/CommitIdGenerator.java
@@ -29,13 +29,13 @@ public enum CommitIdGenerator {
      * Suitable for distributed applications.<br/>
      *
      * <b>Warning!</b> When RANDOM generator is set,
-     * Shadow query runner sorts commits by commitDate.
+     * Shadow query runner sorts commits by commitDateInstant.
      * It means, that Shadow queries would be correct only
      * if all application servers have synchronized clocks.
      */
     RANDOM {
         public Comparator<CommitMetadata> getComparator() {
-            return Comparator.comparing(CommitMetadata::getCommitDate);
+            return Comparator.comparing(CommitMetadata::getCommitDateInstant);
         }
     },
 
@@ -44,7 +44,7 @@ public enum CommitIdGenerator {
      */
     CUSTOM {
         public Comparator<CommitMetadata> getComparator() {
-            return Comparator.comparing(CommitMetadata::getCommitDate);
+            return Comparator.comparing(CommitMetadata::getCommitDateInstant);
         }
     };
 

--- a/javers-core/src/main/java/org/javers/core/commit/Commit.java
+++ b/javers-core/src/main/java/org/javers/core/commit/Commit.java
@@ -64,10 +64,24 @@ public final class Commit {
         return diff;
     }
 
+    /**
+     * Commit creation timestamp in local time zone
+     */
     public LocalDateTime getCommitDate() {
         return commitMetadata.getCommitDate();
     }
 
+    /**
+     * Commit creation timestamp in UTC
+     * <br/><br/>
+     *
+     * Since 5.1, commitDateInstant is safely persisted in JaversRepository.
+     * <br/>
+     * In commits persisted by JaVers older then 5.1  &mdash;
+     * commitDateInstant is guessed from commitDate and current {@link java.util.TimeZone}
+     *
+     * @since 5.1
+     */
     public Instant getCommitDateInstant() {
         return commitMetadata.getCommitDateInstant();
     }

--- a/javers-core/src/main/java/org/javers/core/commit/Commit.java
+++ b/javers-core/src/main/java/org/javers/core/commit/Commit.java
@@ -1,6 +1,7 @@
 package org.javers.core.commit;
 
 import org.javers.common.validation.Validate;
+import org.javers.core.CommitIdGenerator;
 import org.javers.core.diff.Change;
 import org.javers.core.diff.Diff;
 import org.javers.core.metamodel.object.Cdo;
@@ -12,6 +13,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 /**
  * JaVers commit is similar notion to GIT <i>commit</i> or SVN <i>revision</i>.
@@ -72,13 +74,17 @@ public final class Commit {
     }
 
     /**
-     * Commit creation timestamp in UTC
+     * Commit creation timestamp in UTC.
      * <br/><br/>
      *
-     * Since 5.1, commitDateInstant is safely persisted in JaversRepository.
-     * <br/>
-     * In commits persisted by JaVers older then 5.1  &mdash;
-     * commitDateInstant is guessed from commitDate and current {@link java.util.TimeZone}
+     * Since 5.1, commitDateInstant is persisted in JaversRepository
+     * to provide reliable chronological ordering, especially when {@link CommitIdGenerator#RANDOM}
+     * is used.
+     *
+     * <br/><br/>
+     *
+     * Commits persisted by JaVers older then 5.1
+     * have commitDateInstant guessed from commitDate and current {@link TimeZone}
      *
      * @since 5.1
      */

--- a/javers-core/src/main/java/org/javers/core/commit/Commit.java
+++ b/javers-core/src/main/java/org/javers/core/commit/Commit.java
@@ -6,7 +6,9 @@ import org.javers.core.diff.Diff;
 import org.javers.core.metamodel.object.Cdo;
 import org.javers.core.metamodel.object.CdoSnapshot;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +68,10 @@ public final class Commit {
         return commitMetadata.getCommitDate();
     }
 
+    public Instant getCommitDateInstant() {
+        return commitMetadata.getCommitDateInstant();
+    }
+
     /**
      * @return unmodifiableList
      */
@@ -86,7 +92,6 @@ public final class Commit {
         b.append("Commit(id:" + commitMetadata.getId());
         b.append(", snapshots:" + snapshots.size());
         b.append(", author:" + commitMetadata.getAuthor());
-        //b.append(", date:" + commitMetadata.getCommitDate());
         b.append(", " + diff.changesSummary());
         b.append(")");
         return b.toString();

--- a/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
+++ b/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
@@ -1,11 +1,9 @@
 package org.javers.core.commit;
 
 import org.javers.common.collections.Lists;
-import java.util.Optional;
 import org.javers.common.date.DateProvider;
 import org.javers.common.exception.JaversException;
 import org.javers.common.exception.JaversExceptionCode;
-import org.javers.common.validation.Validate;
 import org.javers.core.diff.Diff;
 import org.javers.core.diff.DiffFactory;
 import org.javers.core.diff.ObjectGraph;
@@ -19,11 +17,12 @@ import org.javers.core.snapshot.SnapshotFactory;
 import org.javers.core.snapshot.SnapshotGraphFactory;
 import org.javers.repository.api.JaversExtendedRepository;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.javers.common.validation.Validate.argumentsAreNotNull;
@@ -97,6 +96,9 @@ public class CommitFactory {
     }
 
     private CommitMetadata newCommitMetadata(String author, Map<String, String> properties){
-        return new CommitMetadata(author, properties, dateProvider.now(), commitIdFactory.nextId());
+        ZonedDateTime now = dateProvider.now();
+        return new CommitMetadata(author, properties,
+                now.toLocalDateTime(), now.toInstant(),
+                commitIdFactory.nextId());
     }
 }

--- a/javers-core/src/main/java/org/javers/core/commit/CommitMetadata.java
+++ b/javers-core/src/main/java/org/javers/core/commit/CommitMetadata.java
@@ -49,24 +49,10 @@ public class CommitMetadata implements Serializable {
         return unmodifiableMap(properties);
     }
 
-    /**
-     * Commit creation timestamp in local time zone
-     */
     public LocalDateTime getCommitDate() {
         return commitDate;
     }
 
-    /**
-     * Commit creation timestamp in UTC
-     * <br/><br/>
-     *
-     * Since 5.1, commitDateInstant is safely persisted in JaversRepository.
-     * <br/>
-     * In commits persisted by JaVers older then 5.1  &mdash;
-     * commitDateInstant is guessed from commitDate and current {@link java.util.TimeZone}
-     *
-     * @since 5.1
-     */
     public Instant getCommitDateInstant() {
         return commitDateInstant;
     }

--- a/javers-core/src/main/java/org/javers/core/json/CdoSnapshotSerialized.java
+++ b/javers-core/src/main/java/org/javers/core/json/CdoSnapshotSerialized.java
@@ -3,6 +3,7 @@ package org.javers.core.json;
 import org.javers.core.json.typeadapter.util.UtilTypeCoreAdapters;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Map;
@@ -12,6 +13,7 @@ public class CdoSnapshotSerialized {
     private Map<String, String> commitProperties;
     private String commitAuthor;
     private LocalDateTime commitDate;
+    private Instant commitDateInstant;
     private BigDecimal commitId;
     private long commitPk;
 
@@ -36,6 +38,11 @@ public class CdoSnapshotSerialized {
 
     public CdoSnapshotSerialized withCommitAuthor(String commitAuthor) {
         this.commitAuthor = commitAuthor;
+        return this;
+    }
+
+    public CdoSnapshotSerialized withCommitDateInstant(String commitDateInstant) {
+        this.commitDateInstant = Instant.parse(commitDateInstant);
         return this;
     }
 
@@ -120,6 +127,10 @@ public class CdoSnapshotSerialized {
 
     public LocalDateTime getCommitDate() {
         return commitDate;
+    }
+
+    public Instant getCommitDateInstant() {
+        return commitDateInstant;
     }
 
     public BigDecimal getCommitId() {

--- a/javers-core/src/main/java/org/javers/core/json/typeadapter/commit/CdoSnapshotAssembler.java
+++ b/javers-core/src/main/java/org/javers/core/json/typeadapter/commit/CdoSnapshotAssembler.java
@@ -71,6 +71,7 @@ public class CdoSnapshotAssembler {
         jsonObject.addProperty(AUTHOR, snapshot.getCommitAuthor());
         jsonObject.add(PROPERTIES, CommitPropertiesConverter.toJson(snapshot.getCommitProperties()));
         jsonObject.add(COMMIT_DATE, jsonConverter.toJsonElement(snapshot.getCommitDate()));
+        jsonObject.add(COMMIT_DATE_INSTANT, jsonConverter.toJsonElement(snapshot.getCommitDateInstant()));
         jsonObject.add(COMMIT_ID, jsonConverter.toJsonElement(snapshot.getCommitId()));
 
         return jsonObject;

--- a/javers-core/src/main/java/org/javers/core/json/typeadapter/commit/CommitMetadataTypeAdapter.java
+++ b/javers-core/src/main/java/org/javers/core/json/typeadapter/commit/CommitMetadataTypeAdapter.java
@@ -8,6 +8,7 @@ import org.javers.core.commit.CommitId;
 import org.javers.core.commit.CommitMetadata;
 import org.javers.core.json.JsonTypeAdapterTemplate;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -16,6 +17,7 @@ class CommitMetadataTypeAdapter extends JsonTypeAdapterTemplate<CommitMetadata> 
     static final String AUTHOR = "author";
     static final String PROPERTIES = "properties";
     static final String COMMIT_DATE = "commitDate";
+    static final String COMMIT_DATE_INSTANT = "commitDateInstant";
     static final String COMMIT_ID = "id";
 
     @Override
@@ -29,8 +31,9 @@ class CommitMetadataTypeAdapter extends JsonTypeAdapterTemplate<CommitMetadata> 
         String author = jsonObject.get(AUTHOR).getAsString();
         Map<String, String> properties = CommitPropertiesConverter.fromJson(jsonObject.get(PROPERTIES));
         LocalDateTime commitDate = context.deserialize(jsonObject.get(COMMIT_DATE), LocalDateTime.class);
+        Instant commitDateInstant = context.deserialize(jsonObject.get(COMMIT_DATE_INSTANT), Instant.class);
         CommitId id = context.deserialize(jsonObject.get(COMMIT_ID), CommitId.class);
-        return new CommitMetadata(author, properties, commitDate, id);
+        return new CommitMetadata(author, properties, commitDate, commitDateInstant, id);
     }
 
     @Override
@@ -39,9 +42,8 @@ class CommitMetadataTypeAdapter extends JsonTypeAdapterTemplate<CommitMetadata> 
         jsonObject.addProperty(AUTHOR, commitMetadata.getAuthor());
         jsonObject.add(PROPERTIES, CommitPropertiesConverter.toJson(commitMetadata.getProperties()));
         jsonObject.add(COMMIT_DATE, context.serialize(commitMetadata.getCommitDate(), LocalDateTime.class));
+        jsonObject.add(COMMIT_DATE_INSTANT, context.serialize(commitMetadata.getCommitDateInstant(), Instant.class));
         jsonObject.add(COMMIT_ID, context.serialize(commitMetadata.getId()));
         return jsonObject;
     }
-
-
 }

--- a/javers-core/src/main/java/org/javers/core/json/typeadapter/util/UtilTypeCoreAdapters.java
+++ b/javers-core/src/main/java/org/javers/core/json/typeadapter/util/UtilTypeCoreAdapters.java
@@ -17,8 +17,6 @@ import java.util.List;
 public class UtilTypeCoreAdapters {
     private static final DateTimeFormatter ISO_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
-    public static final ZoneId UTC = ZoneId.of("UTC");
-
     public static LocalDateTime deserialize(String date) {
         return LocalDateTime.parse(date, ISO_FORMAT);
     }
@@ -33,13 +31,13 @@ public class UtilTypeCoreAdapters {
 
     public static LocalDateTime fromUtilDate(Date date) {
         if (date.getClass() == Date.class) {
-            return LocalDateTime.ofInstant(date.toInstant(), UTC);
+            return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
         }
         return fromUtilDate(new Date(date.getTime())); //hack for old java.sql.Date
     }
 
     public static Date toUtilDate(LocalDateTime localDateTime) {
-        return Date.from(localDateTime.toInstant(ZoneOffset.UTC));
+        return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
     }
 
     public static String serialize(Date date) {

--- a/javers-core/src/test/groovy/org/javers/core/FakeDateProvider.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/FakeDateProvider.groovy
@@ -5,24 +5,21 @@ import org.javers.common.date.DateProvider
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZonedDateTime
 
 class FakeDateProvider implements DateProvider {
-    private LocalDateTime localDateTime
+    private ZonedDateTime dateTime
 
     FakeDateProvider() {
-        this.localDateTime = localDateTime
+        this.dateTime = dateTime
     }
 
     @Override
-    LocalDateTime now() {
-        localDateTime ? localDateTime : LocalDateTime.now()
+    ZonedDateTime now() {
+        dateTime ? dateTime : ZonedDateTime.now()
     }
 
-    void set(LocalDate localDate) {
-        this.localDateTime = localDate.atTime(LocalTime.MIDNIGHT)
-    }
-
-    void set(LocalDateTime localDateTime) {
-        this.localDateTime = localDateTime
+    void set(ZonedDateTime dateTime) {
+        this.dateTime = dateTime
     }
 }

--- a/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
@@ -13,6 +13,9 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import org.javers.core.model.*
 
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+
 import static org.javers.common.exception.JaversExceptionCode.VALUE_OBJECT_IS_NOT_SUPPORTED_AS_MAP_KEY
 import static org.javers.core.JaversBuilder.javers
 import static org.javers.core.model.DummyUser.dummyUser

--- a/javers-core/src/test/groovy/org/javers/core/JaversTestBuilder.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversTestBuilder.groovy
@@ -49,7 +49,7 @@ class JaversTestBuilder {
 
     private JaversTestBuilder (DateProvider dateProvider) {
         javersBuilder = new JaversBuilder()
-        javersBuilder.withDateProvider(dateProvider).build()
+        javersBuilder.withDateTimeProvider(dateProvider).build()
     }
 
     private JaversTestBuilder (JaversRepository javersRepository) {

--- a/javers-core/src/test/groovy/org/javers/core/TikDateProvider.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/TikDateProvider.groovy
@@ -2,19 +2,19 @@ package org.javers.core
 
 import org.javers.common.date.DateProvider
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 class TikDateProvider implements DateProvider {
-    private LocalDateTime localDateTime = LocalDateTime.now()
+    private ZonedDateTime dateTime = ZonedDateTime.now()
 
-    void set(LocalDateTime now) {
-        localDateTime = now
+    void set(ZonedDateTime now) {
+        dateTime = now
     }
 
     @Override
-    synchronized LocalDateTime now() {
-        def now = localDateTime
-        localDateTime = localDateTime.plusSeconds(1)
+    synchronized ZonedDateTime now() {
+        def now = dateTime
+        dateTime = dateTime.plusSeconds(1)
         now
     }
 }

--- a/javers-core/src/test/groovy/org/javers/core/commit/CommitMetadataTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/commit/CommitMetadataTest.groovy
@@ -1,0 +1,25 @@
+package org.javers.core.commit
+
+import spock.lang.Specification
+
+import java.time.ZonedDateTime
+
+class CommitMetadataTest extends Specification {
+
+    def "should init commitDateInstant from commitDate using current Zone if commitDateInstant is null "(){
+      given:
+      def nowZ = ZonedDateTime.now()
+      def nowI = nowZ.toInstant()
+      def nowL = nowZ.toLocalDateTime()
+
+      println 'now Instant: '+ nowI
+      println 'now LocalDateTime: '+ nowL
+
+      when:
+      def c = new CommitMetadata('', [:], nowL, null, new CommitId(1,1))
+
+      then:
+      c.commitDate == nowL
+      c.commitDateInstant == nowI
+    }
+}

--- a/javers-core/src/test/groovy/org/javers/core/examples/JqlExample.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/examples/JqlExample.groovy
@@ -17,6 +17,8 @@ import org.javers.repository.jql.QueryBuilder
 import spock.lang.Specification
 
 import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 /**
  * @author bartosz.walacik
@@ -480,7 +482,7 @@ class JqlExample extends Specification {
       def javers = JaversBuilder.javers().withDateTimeProvider(fakeDateProvider).build()
 
       (0..5).each{ i ->
-          def now = new LocalDate(2015+i,01,1)
+          def now = ZonedDateTime.of(2015+i,01,1,0,0,0,0, ZoneId.of("UTC"))
           fakeDateProvider.set( now )
           def bob = new Employee(name:"bob", age:20+i)
           javers.commit("author", bob)

--- a/javers-core/src/test/groovy/org/javers/core/snapshot/ChangedCdoSnapshotsFactoryTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/snapshot/ChangedCdoSnapshotsFactoryTest.groovy
@@ -28,7 +28,7 @@ class ChangedCdoSnapshotsFactoryTest extends Specification {
     }
 
     CommitMetadata someCommitMetadata(){
-        new CommitMetadata("kazik", [:], LocalDateTime.now(), new CommitId(1, 0))
+        new CommitMetadata("kazik", [:], LocalDateTime.now(), null, new CommitId(1, 0))
     }
 
     def "should not mark snapshot as initial even if not present in previous commit but committed before"() {

--- a/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotFactoryTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotFactoryTest.groovy
@@ -324,6 +324,6 @@ class SnapshotFactoryTest extends Specification{
     }
 
     def someCommitMetadata(){
-        new CommitMetadata("kazik", [:], LocalDateTime.now(), new CommitId(1, 0))
+        new CommitMetadata("kazik", [:], LocalDateTime.now(), null, new CommitId(1, 0))
     }
 }

--- a/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepository.java
+++ b/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepository.java
@@ -240,7 +240,7 @@ public class MongoRepository implements JaversRepository, ConfigurationAware {
             findIterable.sort(new Document(COMMIT_ID, DESC));
         }
         else {
-            findIterable.sort(new Document(COMMIT_DATE, DESC));
+            findIterable.sort(new Document(COMMIT_DATE_INSTANT, DESC));
         }
 
         return applyQueryParams(findIterable, queryParams).iterator();

--- a/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoSchemaManager.java
+++ b/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoSchemaManager.java
@@ -18,6 +18,7 @@ class MongoSchemaManager {
     static final String SNAPSHOTS = "jv_snapshots";
     static final String COMMIT_ID = "commitMetadata.id";
     static final String COMMIT_DATE = "commitMetadata.commitDate";
+    static final String COMMIT_DATE_INSTANT = "commitMetadata.commitDateInstant";
     static final String COMMIT_AUTHOR = "commitMetadata.author";
     static final String COMMIT_PROPERTIES = "commitMetadata.properties";
     static final String GLOBAL_ID_KEY = "globalId_key";

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/JaversSqlRepository.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/JaversSqlRepository.java
@@ -86,7 +86,7 @@ public class JaversSqlRepository implements JaversRepository {
     @Override
     public void persist(Commit commit) {
         try(Session session = sessionFactory.create("persist commit")) {
-            long commitPk = commitRepository.save(commit.getAuthor(), commit.getProperties(), commit.getCommitDate(), commit.getId(), session);
+            long commitPk = commitRepository.save(commit.getAuthor(), commit.getProperties(), commit.getCommitDate(), commit.getCommitDateInstant(), commit.getId(), session);
             cdoSnapshotRepository.save(commitPk, commit.getSnapshots(), session);
         }
     }

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/SnapshotQuery.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/finders/SnapshotQuery.java
@@ -37,6 +37,7 @@ class SnapshotQuery {
                 COMMIT_PK + ", " +
                 COMMIT_AUTHOR + ", " +
                 COMMIT_COMMIT_DATE + ", " +
+                COMMIT_COMMIT_DATE_INSTANT + ", " +
                 COMMIT_COMMIT_ID + ", " +
                 "g." + GLOBAL_ID_LOCAL_ID + ", " +
                 "g." + GLOBAL_ID_FRAGMENT + ", " +
@@ -162,6 +163,7 @@ class SnapshotQuery {
             return new CdoSnapshotSerialized()
                     .withCommitAuthor(resultSet.getString(COMMIT_AUTHOR))
                     .withCommitDate(resultSet.getTimestamp(COMMIT_COMMIT_DATE))
+                    .withCommitDateInstant(resultSet.getString(COMMIT_COMMIT_DATE_INSTANT))
                     .withCommitId(resultSet.getBigDecimal(COMMIT_COMMIT_ID))
                     .withCommitPk(resultSet.getLong(COMMIT_PK))
                     .withVersion(resultSet.getLong(SNAPSHOT_VERSION))

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/FixedSchemaFactory.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/FixedSchemaFactory.java
@@ -29,6 +29,7 @@ public class FixedSchemaFactory extends SchemaNameAware {
     public static final String COMMIT_PK =            "commit_pk";
     public static final String COMMIT_AUTHOR =        "author";
     public static final String COMMIT_COMMIT_DATE =   "commit_date";
+    public static final String COMMIT_COMMIT_DATE_INSTANT =   "commit_date_instant";
     public static final String COMMIT_COMMIT_ID =     "commit_id";
     public static final String COMMIT_PK_SEQ =        "jv_commit_pk_seq";
 
@@ -96,6 +97,7 @@ public class FixedSchemaFactory extends SchemaNameAware {
         relationBuilder
                 .withAttribute().string(COMMIT_AUTHOR).withMaxLength(200).and()
                 .withAttribute().timestamp(COMMIT_COMMIT_DATE).and()
+                .withAttribute().string(COMMIT_COMMIT_DATE_INSTANT).withMaxLength(26).and()
                 .withAttribute().number(COMMIT_COMMIT_ID).withIntegerPrecision(22).withDecimalPrecision(2).and()
                 .build();
 

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.*;
 import java.util.Map;
 
+import static org.javers.repository.sql.schema.FixedSchemaFactory.COMMIT_COMMIT_DATE_INSTANT;
 import static org.javers.repository.sql.schema.FixedSchemaFactory.GLOBAL_ID_OWNER_ID_FK;
 
 /**
@@ -60,7 +61,18 @@ public class JaversSchemaManager extends SchemaNameAware {
             addDbIndexOnOwnerId();
         }
 
+        addCommitDateInstantColumnIfNeeded();
+
         TheCloser.close(schemaManager, schemaInspector);
+    }
+
+    /**
+     * JaVers 5.0 to 5.1 schema migration
+     */
+    private void addCommitDateInstantColumnIfNeeded() {
+        if (!columnExists(getCommitTableNameWithSchema(), COMMIT_COMMIT_DATE_INSTANT)){
+            addStringColumn(getCommitTableNameWithSchema(), COMMIT_COMMIT_DATE_INSTANT, 26);
+        }
     }
 
     /**

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
@@ -44,7 +44,7 @@ abstract class JaversSqlRepositoryE2ETest extends JaversRepositoryShadowE2ETest 
 
     def cleanup() {
         connections.each {
-            it.rollback()
+            it.commit()
             it.close()
         }
     }

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
@@ -44,7 +44,7 @@ abstract class JaversSqlRepositoryE2ETest extends JaversRepositoryShadowE2ETest 
 
     def cleanup() {
         connections.each {
-            it.commit()
+            it.rollback()
             it.close()
         }
     }


### PR DESCRIPTION
`Instant commitDateInstant` is added to `CommitMetadata` in order to provide
reliable chronological ordering when applications nodes works in more than one time zone.