### PR TITLE
Sorted set bug test case

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/object/GlobalId.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/object/GlobalId.java
@@ -1,5 +1,6 @@
 package org.javers.core.metamodel.object;
 
+import java.util.Comparator;
 import org.javers.common.validation.Validate;
 import org.javers.core.metamodel.type.ManagedType;
 import org.javers.repository.jql.GlobalIdDTO;
@@ -9,7 +10,7 @@ import java.io.Serializable;
 /**
  * Global ID of Client's domain object (CDO)
  */
-public abstract class GlobalId implements Serializable {
+public abstract class GlobalId implements Serializable, Comparable<GlobalId> {
 
     private final String typeName;
 
@@ -74,5 +75,10 @@ public abstract class GlobalId implements Serializable {
             return "..." + split[split.length-1];
         }
         return getTypeName();
+    }
+
+    @Override
+    public int compareTo(GlobalId o) {
+        return Comparator.comparing(GlobalId::value).compare(this, o);
     }
 }

--- a/javers-core/src/test/java/org/javers/core/cases/Case779SortedSets.java
+++ b/javers-core/src/test/java/org/javers/core/cases/Case779SortedSets.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 /**
  * @author adriano.machado
  */
-public class CaseXXXSortedSets {
+public class Case779SortedSets {
 
     public static class MasterWithSet {
         @Id
@@ -59,7 +59,7 @@ public class CaseXXXSortedSets {
         javers.commit("anonymous", master);
         javers.commit("anonymous", master);
 
-        List<CdoSnapshot> snapshots = javers.findSnapshots(QueryBuilder.byClass(CaseXXXSortedSets.MasterWithSet.class).build());
+        List<CdoSnapshot> snapshots = javers.findSnapshots(QueryBuilder.byClass(MasterWithSet.class).build());
 
         assertThat(snapshots).isNotEmpty();
     }
@@ -79,7 +79,7 @@ public class CaseXXXSortedSets {
         javers.commit("anonymous", master);
         javers.commit("anonymous", master);
 
-        List<CdoSnapshot> snapshots = javers.findSnapshots(QueryBuilder.byClass(CaseXXXSortedSets.MasterWithSortedSet.class).build());
+        List<CdoSnapshot> snapshots = javers.findSnapshots(QueryBuilder.byClass(MasterWithSortedSet.class).build());
 
         assertThat(snapshots).isNotEmpty();
     }

--- a/javers-core/src/test/java/org/javers/core/cases/CaseXXXSortedSets.java
+++ b/javers-core/src/test/java/org/javers/core/cases/CaseXXXSortedSets.java
@@ -1,0 +1,86 @@
+package org.javers.core.cases;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.persistence.Id;
+import org.javers.core.Javers;
+import org.javers.core.JaversBuilder;
+import org.javers.core.metamodel.annotation.ValueObject;
+import org.javers.core.metamodel.object.CdoSnapshot;
+import org.javers.repository.jql.QueryBuilder;
+import org.junit.Test;
+
+/**
+ * @author adriano.machado
+ */
+public class CaseXXXSortedSets {
+
+    public static class MasterWithSet {
+        @Id
+        String id;
+
+        Set<Detail> set;
+    }
+
+    public static class MasterWithSortedSet {
+        @Id
+        String id;
+
+        SortedSet<Detail> sortedSet;
+    }
+
+    @ValueObject
+    public static class Detail {
+        String data;
+
+        Detail(String data) {
+            this.data = data;
+        }
+    }
+
+    @Test
+    public void shouldWorkWithObjectsUsingSets() {
+        //given
+        Javers javers = JaversBuilder.javers().build();
+
+        MasterWithSet master = new MasterWithSet();
+        master.id = "X";
+        master.set = new HashSet<>();
+
+        master.set.add(new Detail("data 2"));
+        master.set.add(new Detail("data 1"));
+
+        javers.commit("anonymous", master);
+        javers.commit("anonymous", master);
+
+        List<CdoSnapshot> snapshots = javers.findSnapshots(QueryBuilder.byClass(CaseXXXSortedSets.MasterWithSet.class).build());
+
+        assertThat(snapshots).isNotEmpty();
+    }
+
+    @Test
+    public void shouldWorkWithObjectsUsingSortedSets() {
+        //given
+        Javers javers = JaversBuilder.javers().build();
+
+        MasterWithSortedSet master = new MasterWithSortedSet();
+        master.id = "X";
+        master.sortedSet = new TreeSet<>(Comparator.comparing(o -> o.data));
+
+        master.sortedSet.add(new Detail("data 2"));
+        master.sortedSet.add(new Detail("data 1"));
+
+        javers.commit("anonymous", master);
+        javers.commit("anonymous", master);
+
+        List<CdoSnapshot> snapshots = javers.findSnapshots(QueryBuilder.byClass(CaseXXXSortedSets.MasterWithSortedSet.class).build());
+
+        assertThat(snapshots).isNotEmpty();
+    }
+}


### PR DESCRIPTION
Client domain object snapshots are unable to deserialize, due the fact that GlobalId instances are not `Comparable`.