### PR TITLE
Amazon DocumentDB compatibility implementation.

### DIFF
--- a/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoSchemaManager.java
+++ b/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoSchemaManager.java
@@ -41,7 +41,7 @@ class MongoSchemaManager {
         this.mongo = mongo;
     }
 
-    public void ensureSchema() {
+    public void ensureSchema(boolean allowCompoundIndex) {
         //ensures collections and indexes
         MongoCollection<Document> snapshots = snapshotsCollection();
         snapshots.createIndex(new BasicDBObject(GLOBAL_ID_KEY, ASC));
@@ -49,8 +49,14 @@ class MongoSchemaManager {
         snapshots.createIndex(new BasicDBObject(GLOBAL_ID_ENTITY, ASC));
         snapshots.createIndex(new BasicDBObject(GLOBAL_ID_OWNER_ID_ENTITY, ASC));
         snapshots.createIndex(new BasicDBObject(CHANGED_PROPERTIES, ASC));
-        snapshots.createIndex(new BasicDBObject(COMMIT_PROPERTIES + ".key", ASC).append(COMMIT_PROPERTIES + ".value", ASC),
-                new IndexOptions().name(COMMIT_PROPERTIES_INDEX_NAME));
+
+        if (allowCompoundIndex) {
+            snapshots.createIndex(new BasicDBObject(COMMIT_PROPERTIES + ".key", ASC).append(COMMIT_PROPERTIES + ".value", ASC),
+                    new IndexOptions().name(COMMIT_PROPERTIES_INDEX_NAME));
+        } else {
+            snapshots.createIndex(new BasicDBObject(COMMIT_PROPERTIES + ".key", ASC));
+            snapshots.createIndex(new BasicDBObject(COMMIT_PROPERTIES + ".value", ASC));
+        }
 
         headCollection();
 

--- a/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoAutoConfiguration.java
+++ b/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoAutoConfiguration.java
@@ -4,7 +4,6 @@ import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
-import org.javers.repository.api.JaversRepository;
 import org.javers.repository.mongo.MongoRepository;
 import org.javers.spring.auditable.*;
 import org.javers.spring.auditable.aspect.JaversAuditableAspect;
@@ -50,7 +49,8 @@ public class JaversMongoAutoConfiguration {
 
         logger.info("connecting to database: {}", mongoProperties.getMongoClientDatabase());
 
-        JaversRepository javersRepository = new MongoRepository(mongoDatabase);
+        MongoRepository javersRepository = new MongoRepository(mongoDatabase);
+        javersRepository.setDocumentDbCompatibilityEnabled(javersMongoProperties.isDocumentDbCompatibilityEnabled());
 
         return JaversBuilder.javers()
                 .registerJaversRepository(javersRepository)

--- a/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoProperties.java
+++ b/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoProperties.java
@@ -9,4 +9,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "javers")
 public class JaversMongoProperties extends JaversSpringProperties {
 
+    private boolean documentDbCompatibilityEnabled = false;
+
+    public boolean isDocumentDbCompatibilityEnabled() {
+        return documentDbCompatibilityEnabled;
+    }
+
+    public void setDocumentDbCompatibilityEnabled(boolean documentDbCompatibilityEnabled) {
+        this.documentDbCompatibilityEnabled = documentDbCompatibilityEnabled;
+    }
+
 }


### PR DESCRIPTION
I took a crack at adding DocumentDB compatibility to the existing MongoRepository. The only functional difference is creation of the commit metadata property index. Let me know if you would prefer supporting this in another way, such as with a seperate JaversRepository implementation.

Thanks!