### PR TITLE
fix toString() bug

### DIFF
--- a/javers-core/src/main/java/org/javers/common/string/ToStringBuilder.java
+++ b/javers-core/src/main/java/org/javers/common/string/ToStringBuilder.java
@@ -34,7 +34,7 @@ public class ToStringBuilder {
 
             out.append( typeName(args[0]));
             for (int i=1;i<args.length;i++){
-                out.append(", "+typeName(args[0]) );
+                out.append(", "+typeName(args[i]) );
             }
             out.append(">");
             return out.toString();


### PR DESCRIPTION
toString always shows discouraging "Field Map<String, String>..." instead of correct "Field Map<String, MyClass>..."