### PR TITLE
Upgrade embedded mongo to 2.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ polyjdbcVersion         =0.7.6
 aspectjweaverVersion    =1.8.13
 spockVersion            =1.2-groovy-2.5
 groovyVersion           =2.5.5
-embeddedMongo           =2.1.1
+embeddedMongo           =2.2.0


### PR DESCRIPTION
Fixes building on windows. 

(Upgrade to 2.1.2 also fixes the error, but I decided to choose the highest.)

Original error with embedded mongo 2.1.1:
```
22:33:45.889 [main] ERROR d.f.e.p.runtime.AbstractProcess - failed to call onAfterProcessStart()
java.io.IOException: Could not start process: <EOF>
	at de.flapdoodle.embed.mongo.AbstractMongoProcess.onAfterProcessStart(AbstractMongoProcess.java:79) [de.flapdoodle.embed.mongo-2.1.1.jar:na]
	at de.flapdoodle.embed.process.runtime.AbstractProcess.<init>(AbstractProcess.java:116) ~[de.flapdoodle.embed.process-2.0.5.jar:na]
	at de.flapdoodle.embed.mongo.AbstractMongoProcess.<init>(AbstractMongoProcess.java:53) [de.flapdoodle.embed.mongo-2.1.1.jar:na]
	at de.flapdoodle.embed.mongo.MongodProcess.<init>(MongodProcess.java:50) [de.flapdoodle.embed.mongo-2.1.1.jar:na]
	at de.flapdoodle.embed.mongo.MongodExecutable.start(MongodExecutable.java:44) [de.flapdoodle.embed.mongo-2.1.1.jar:na]
	at de.flapdoodle.embed.mongo.MongodExecutable.start(MongodExecutable.java:34) [de.flapdoodle.embed.mongo-2.1.1.jar:na]
	at de.flapdoodle.embed.process.runtime.Executable.start(Executable.java:108) [de.flapdoodle.embed.process-2.0.5.jar:na]
	at de.flapdoodle.embed.process.runtime.Executable$start.call(Unknown Source) [de.flapdoodle.embed.process-2.0.5.jar:na]
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47) [groovy-2.5.5.jar:2.5.5]
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115) [groovy-2.5.5.jar:2.5.5]
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:119) [groovy-2.5.5.jar:2.5.5]
	at org.javers.repository.mongo.EmbeddedMongoFactory$EmbeddedMongo.<init>(EmbeddedMongoFactory.groovy:28) [classes/:na]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) [na:na]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) [na:na]
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) [na:na]
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:488) [na:na]
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:83) [groovy-2.5.5.jar:2.5.5]
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:105) [groovy-2.5.5.jar:2.5.5]
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:59) [groovy-2.5.5.jar:2.5.5]
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:237) [groovy-2.5.5.jar:2.5.5]
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:249) [groovy-2.5.5.jar:2.5.5]
	at org.javers.repository.mongo.EmbeddedMongoFactory.create(EmbeddedMongoFactory.groovy:44) [classes/:na]

```