### PR TITLE
https://github.com/javers/javers/issues/888

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/type/ListType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/ListType.java
@@ -8,10 +8,8 @@ import org.javers.core.metamodel.object.OwnerContext;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
@@ -20,6 +18,11 @@ public class ListType extends CollectionType{
 
     public ListType(Type baseJavaType) {
         super(baseJavaType);
+    }
+
+    @Override
+    public boolean isInstance(Object cdo) {
+        return super.isInstance(cdo) || cdo instanceof List;
     }
 
     /**

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/MapType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/MapType.java
@@ -21,6 +21,11 @@ public class MapType extends KeyValueType {
     }
 
     @Override
+    public boolean isInstance(Object cdo) {
+        return super.isInstance(cdo) || cdo instanceof Map;
+    }
+
+    @Override
     public Object map(Object sourceEnumerable, EnumerableFunction mapFunction, OwnerContext owner) {
         return mapStatic(sourceEnumerable, mapFunction, owner);
     }

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/SetType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/SetType.java
@@ -13,6 +13,12 @@ import java.util.stream.Collectors;
 import static java.util.Collections.unmodifiableSet;
 
 public class SetType extends CollectionType{
+
+    @Override
+    public boolean isInstance(Object cdo) {
+        return super.isInstance(cdo) || cdo instanceof Set;
+    }
+
     public SetType(Type baseJavaType) {
         super(baseJavaType);
     }

--- a/javers-core/src/main/java/org/javers/guava/MultimapType.java
+++ b/javers-core/src/main/java/org/javers/guava/MultimapType.java
@@ -12,7 +12,7 @@ import org.javers.core.metamodel.type.MapEnumerationOwnerContext;
 import org.javers.core.metamodel.type.MapType;
 
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -66,6 +66,11 @@ public class MultimapType extends KeyValueType {
         MapType.mapEntrySet(sourceMultimap.entries(), mapFunction, (k,v) -> targetMultimap.put(k,v), filterNulls);
 
         return targetMultimap;
+    }
+
+    @Override
+    public boolean isInstance(Object cdo) {
+        return super.isInstance(cdo) || cdo instanceof Multimap;
     }
 
     @Override

--- a/javers-core/src/main/java/org/javers/guava/MultisetType.java
+++ b/javers-core/src/main/java/org/javers/guava/MultisetType.java
@@ -8,7 +8,6 @@ import org.javers.common.validation.Validate;
 import org.javers.core.metamodel.object.EnumerationAwareOwnerContext;
 import org.javers.core.metamodel.object.OwnerContext;
 import org.javers.core.metamodel.type.CollectionType;
-import org.javers.core.metamodel.type.SetType;
 
 import java.lang.reflect.Type;
 import java.util.function.Function;
@@ -24,6 +23,11 @@ public class MultisetType extends CollectionType {
 
     public MultisetType(Type baseJavaType) {
         super(baseJavaType);
+    }
+
+    @Override
+    public boolean isInstance(Object cdo) {
+        return super.isInstance(cdo) || cdo instanceof Multiset;
     }
 
     /**

--- a/javers-core/src/test/groovy/org/javers/core/cases/CaseWithSortedCollectionPropertyType.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/cases/CaseWithSortedCollectionPropertyType.groovy
@@ -1,0 +1,150 @@
+package org.javers.core.cases
+
+import groovy.transform.ToString
+import groovy.transform.TupleConstructor
+import org.javers.core.JaversBuilder
+import org.javers.core.diff.changetype.container.SetChange
+import org.javers.core.diff.changetype.map.MapChange
+import org.javers.core.metamodel.annotation.Id
+import spock.lang.Specification
+
+class CaseWithSortedCollectionPropertyType extends Specification {
+
+    def javers = JaversBuilder
+            .javers()
+            .registerValueObject(DummyValueObject)
+            .build()
+
+    def "can detect new element added to set property"() {
+        given:
+        def a = new DummyEntity(
+                1,
+                "foo",
+                [].toSet()
+        )
+
+        def b = new DummyEntity(
+                a.id,
+                a.name,
+                a.valueObjectSet + new DummyValueObject("bar"),
+        )
+
+        when:
+        def diff = javers.compare(a, b)
+        println diff
+
+        then:
+        diff.hasChanges()
+        diff.changes.any() { change ->
+            change instanceof SetChange
+        }
+    }
+
+    def "can detect new element added to sorted set property"() {
+        given:
+        def a = new DummyEntity(
+                1,
+                "foo",
+                null,
+                new TreeSet<DummyValueObject>()
+        )
+
+        def b = new DummyEntity(
+                a.id,
+                a.name,
+                a.valueObjectSet,
+                a.valueObjectSortedSet + new DummyValueObject("bar"),
+        )
+
+        when:
+        def diff = javers.compare(a, b)
+        println diff
+
+        then:
+        diff.hasChanges()
+        diff.changes.any() { change ->
+            change instanceof SetChange
+        }
+    }
+
+    def "can detect new element added to map property"() {
+        given:
+        def a = new DummyEntity(
+                1,
+                "foo",
+                null,
+                null,
+                [:]
+        )
+
+        def b = new DummyEntity(
+                a.id,
+                a.name,
+                a.valueObjectSet,
+                a.valueObjectSortedSet,
+                a.valueObjectMap + ["3": new DummyValueObject("bar")]
+        )
+
+        when:
+        def diff = javers.compare(a, b)
+        println diff
+
+        then:
+        diff.hasChanges()
+        diff.changes.any() { change ->
+            change instanceof MapChange && !change.entryAddedChanges.isEmpty()
+        }
+    }
+
+    def "can detect new element added to sorted map property"() {
+        given:
+        def a = new DummyEntity(
+                1,
+                "foo"
+        )
+
+        def sortedMap = new TreeMap<String, DummyValueObject>()
+        sortedMap.put("3", new DummyValueObject("bar"))
+
+        def b = new DummyEntity(
+                a.id,
+                a.name,
+                a.valueObjectSet,
+                a.valueObjectSortedSet,
+                a.valueObjectMap,
+                sortedMap
+        )
+
+        when:
+        def diff = javers.compare(a, b)
+        println diff
+
+        then:
+        diff.hasChanges()
+        diff.changes.any() { change ->
+            change instanceof MapChange && !change.entryAddedChanges.isEmpty()
+        }
+    }
+}
+
+@TupleConstructor
+class DummyEntity {
+    @Id
+    final int id
+    final String name
+    final Set<DummyValueObject> valueObjectSet
+    final SortedSet<DummyValueObject> valueObjectSortedSet
+    final Map<String, DummyValueObject> valueObjectMap
+    final SortedMap<String, DummyValueObject> valueObjectSortedMap
+}
+
+@ToString
+@TupleConstructor
+class DummyValueObject implements Comparable<DummyValueObject> {
+    final String name
+
+    @Override
+    int compareTo(DummyValueObject that) {
+        return name <=> that.name
+    }
+}


### PR DESCRIPTION
Fixed the regression in generating changes when property types are sub-types of base enumerable types (e.g., SortedMap, SortedSet, etc.)