### PR TITLE
Update comparator for Synchronized Sequence to be safer with distributed systems

### DIFF
--- a/javers-core/src/main/java/org/javers/core/CommitIdGenerator.java
+++ b/javers-core/src/main/java/org/javers/core/CommitIdGenerator.java
@@ -18,8 +18,8 @@ public enum CommitIdGenerator {
      */
     SYNCHRONIZED_SEQUENCE {
         public Comparator<CommitMetadata> getComparator() {
-            return Comparator.comparing(CommitMetadata::getId)
-                    .thenComparing(CommitMetadata::getCommitDateInstant);
+            return Comparator.comparing(CommitMetadata::getCommitDateInstant)
+                    .thenComparing(CommitMetadata::getId);
         }
     },
 

--- a/javers-core/src/main/java/org/javers/core/CommitIdGenerator.java
+++ b/javers-core/src/main/java/org/javers/core/CommitIdGenerator.java
@@ -18,7 +18,8 @@ public enum CommitIdGenerator {
      */
     SYNCHRONIZED_SEQUENCE {
         public Comparator<CommitMetadata> getComparator() {
-            return Comparator.comparing(CommitMetadata::getId);
+            return Comparator.comparing(CommitMetadata::getId)
+                    .thenComparing(CommitMetadata::getCommitDateInstant);
         }
     },
 

--- a/javers-core/src/test/groovy/org/javers/core/CommitIdGeneratorTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/CommitIdGeneratorTest.groovy
@@ -1,0 +1,54 @@
+package org.javers.core
+
+
+import org.javers.core.commit.CommitId
+import org.javers.core.commit.CommitMetadata
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Instant
+import java.time.LocalDateTime
+
+class CommitIdGeneratorTest extends Specification {
+
+    @Unroll
+    def "Commit Id Comparator should distinguish between duplicate commit ids with different timestamps in metadata"() {
+        given:
+        def firstDate = LocalDateTime.now()
+        def firstInstant = Instant.now()
+        def laterDate = firstDate.plusSeconds(1)
+        def laterInstant = firstInstant.plusSeconds(1)
+        def earlierDate = firstDate.plusSeconds(-1)
+        def earlierInstant = firstInstant.plusSeconds(-1)
+        def commitId = new CommitId(2, 0)
+
+        def commitMetadata0 = new CommitMetadata("duro", [:], firstDate, firstInstant, new CommitId(1, 0))
+        def commitMetadata1 = new CommitMetadata("duro", [:], earlierDate, earlierInstant, commitId)
+        def commitMetadata2 = new CommitMetadata("duro", [:], firstDate, firstInstant, commitId)
+        def commitMetadata3 = new CommitMetadata("duro", [:], laterDate, laterInstant, commitId)
+        def commitMetadata4 = new CommitMetadata("duro", [:], firstDate, firstInstant, new CommitId(3, 0))
+
+        when: "List containing duplicate commit ids is sorted"
+        def metadataList = new ArrayList<CommitMetadata>()
+        metadataList.add(commitMetadata4)
+        metadataList.add(commitMetadata2)
+        metadataList.add(commitMetadata0)
+        metadataList.add(commitMetadata3)
+        metadataList.add(commitMetadata1)
+        metadataList.sort(CommitIdGenerator.SYNCHRONIZED_SEQUENCE.comparator)
+
+        then: "Sort includes commit id and timestamp for ordering"
+        metadataList.get(0) == commitMetadata0
+        metadataList.get(1) == commitMetadata1
+        metadataList.get(2) == commitMetadata2
+        metadataList.get(3) == commitMetadata3
+        metadataList.get(4) == commitMetadata4
+
+        // Seperately verify timestamps
+        metadataList.get(1).commitDateInstant == commitMetadata1.commitDateInstant
+        metadataList.get(2).commitDateInstant == commitMetadata2.commitDateInstant
+        metadataList.get(3).commitDateInstant == commitMetadata3.commitDateInstant
+
+    }
+
+}

--- a/javers-core/src/test/groovy/org/javers/core/CommitIdGeneratorTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/CommitIdGeneratorTest.groovy
@@ -22,11 +22,11 @@ class CommitIdGeneratorTest extends Specification {
         def earlierInstant = firstInstant.plusSeconds(-1)
         def commitId = new CommitId(2, 0)
 
-        def commitMetadata0 = new CommitMetadata("duro", [:], firstDate, firstInstant, new CommitId(1, 0))
-        def commitMetadata1 = new CommitMetadata("duro", [:], earlierDate, earlierInstant, commitId)
+        def commitMetadata0 = new CommitMetadata("duro", [:], earlierDate, earlierInstant, commitId)
+        def commitMetadata1 = new CommitMetadata("duro", [:], firstDate, firstInstant, new CommitId(1, 0))
         def commitMetadata2 = new CommitMetadata("duro", [:], firstDate, firstInstant, commitId)
-        def commitMetadata3 = new CommitMetadata("duro", [:], laterDate, laterInstant, commitId)
-        def commitMetadata4 = new CommitMetadata("duro", [:], firstDate, firstInstant, new CommitId(3, 0))
+        def commitMetadata3 = new CommitMetadata("duro", [:], firstDate, firstInstant, new CommitId(3, 0))
+        def commitMetadata4 = new CommitMetadata("duro", [:], laterDate, laterInstant, commitId)
 
         when: "List containing duplicate commit ids is sorted"
         def metadataList = new ArrayList<CommitMetadata>()
@@ -37,7 +37,7 @@ class CommitIdGeneratorTest extends Specification {
         metadataList.add(commitMetadata1)
         metadataList.sort(CommitIdGenerator.SYNCHRONIZED_SEQUENCE.comparator)
 
-        then: "Sort includes commit id and timestamp for ordering"
+        then: "Sort includes timestamp and commit id for ordering"
         metadataList.get(0) == commitMetadata0
         metadataList.get(1) == commitMetadata1
         metadataList.get(2) == commitMetadata2
@@ -45,9 +45,9 @@ class CommitIdGeneratorTest extends Specification {
         metadataList.get(4) == commitMetadata4
 
         // Seperately verify timestamps
+        metadataList.get(0).commitDateInstant == commitMetadata0.commitDateInstant
         metadataList.get(1).commitDateInstant == commitMetadata1.commitDateInstant
-        metadataList.get(2).commitDateInstant == commitMetadata2.commitDateInstant
-        metadataList.get(3).commitDateInstant == commitMetadata3.commitDateInstant
+        metadataList.get(4).commitDateInstant == commitMetadata4.commitDateInstant
 
     }
 


### PR DESCRIPTION
Provides some level of security over duplicated commits when comparing shadows
Without this additional criteria, shadows with the same commit id will get the commit metadata from the earliest commit, rather than the commit associated to the shadow object

https://github.com/javers/javers/issues/894