### PR TITLE
removed throwing of CANT_SAVE_ALREADY_PERSISTED_COMMIT exception

### DIFF
--- a/javers-core/src/main/java/org/javers/common/exception/JaversExceptionCode.java
+++ b/javers-core/src/main/java/org/javers/common/exception/JaversExceptionCode.java
@@ -97,7 +97,6 @@ public enum JaversExceptionCode {
             "it doesn't exists in JaversRepository"),
 
     CANT_FIND_COMMIT_HEAD_ID("can't find commit head id in JaversRepository"),
-    CANT_SAVE_ALREADY_PERSISTED_COMMIT("can't save already persisted commit '%s'"),
 
     SQL_EXCEPTION("%s\nwhile executing sql: %s"),
 

--- a/javers-core/src/main/java/org/javers/core/commit/DistributedCommitSeqGenerator.java
+++ b/javers-core/src/main/java/org/javers/core/commit/DistributedCommitSeqGenerator.java
@@ -5,10 +5,8 @@ import java.util.UUID;
 /**
  * Generates commitId with random majorId and minorId set to 0.
  *
- *  @deprecated
  * @author bartosz.walacik
  */
-@Deprecated
 class DistributedCommitSeqGenerator {
     CommitId nextId() {
         return new CommitId(Math.abs(UUID.randomUUID().getLeastSignificantBits()),0);

--- a/javers-persistence-sql/build.gradle
+++ b/javers-persistence-sql/build.gradle
@@ -12,10 +12,12 @@ dependencies {
     testCompile 'com.h2database:h2:1.4.187'
     testCompile 'org.postgresql:postgresql:42.2.5'
     testCompile 'org.mariadb.jdbc:mariadb-java-client:2.2.3'
+    testCompile 'mysql:mysql-connector-java:8.0.14'
     testCompile 'org.codehaus.gpars:gpars:1.2.1'
     testCompile "joda-time:joda-time:$jodaVersion"
     testCompile "org.testcontainers:mssqlserver:$testcontainers"
     testCompile "org.testcontainers:postgresql:$testcontainers"
+    testCompile "org.testcontainers:mysql:$testcontainers"
     testCompile "org.testcontainers:oracle-xe:$testcontainers"
     testCompile "com.microsoft.sqlserver:mssql-jdbc:7.2.1.jre8"
     testCompile "com.oracle.ojdbc:ojdbc8:19.3.0.0"

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/CommitMetadataRepository.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/repositories/CommitMetadataRepository.java
@@ -1,9 +1,6 @@
 package org.javers.repository.sql.repositories;
 
-import org.javers.common.exception.JaversException;
-import org.javers.common.exception.JaversExceptionCode;
 import org.javers.core.commit.CommitId;
-import org.javers.core.commit.CommitMetadata;
 import org.javers.core.json.typeadapter.util.UtilTypeCoreAdapters;
 import org.javers.repository.sql.schema.SchemaNameAware;
 import org.javers.repository.sql.schema.TableNameProvider;
@@ -13,7 +10,6 @@ import org.polyjdbc.core.type.Timestamp;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Optional;
 
@@ -29,10 +25,6 @@ public class CommitMetadataRepository extends SchemaNameAware {
     }
 
     public long save(String author, Map<String, String> properties, LocalDateTime date, Instant dateInstant, CommitId commitId, Session session) {
-        if (isCommitPersisted(commitId, session)) {
-            throw new JaversException(JaversExceptionCode.CANT_SAVE_ALREADY_PERSISTED_COMMIT, commitId);
-        }
-
         long commitPk = session.insert("Commit")
                 .into(getCommitTableNameWithSchema())
                 .value(COMMIT_AUTHOR, author)

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2ETest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2ETest.groovy
@@ -12,16 +12,24 @@ import static org.javers.repository.sql.SqlRepositoryBuilder.sqlRepository
 
 class H2SqlRepositoryE2ETest extends JaversSqlRepositoryE2ETest {
 
+    @Override
     Connection createConnection() {
         DriverManager.getConnection("jdbc:h2:mem:test")
     }
 
+    @Override
     DialectName getDialect() {
         DialectName.H2
     }
 
+    @Override
     String getSchema() {
         return null
+    }
+
+    @Override
+    boolean useRandomCommitIdGenerator() {
+        false
     }
 
     def "should fail when schema is not created"(){

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2EWithSchemaTest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/H2SqlRepositoryE2EWithSchemaTest.groovy
@@ -8,11 +8,13 @@ import java.sql.DriverManager
  */
 class H2SqlRepositoryE2EWithSchemaTest extends H2SqlRepositoryE2ETest {
 
+    @Override
     Connection createConnection() {
         DriverManager.getConnection(
                 "jdbc:h2:mem:javers;INIT=create schema if not exists javers")
     }
 
+    @Override
     String getSchema() {
         return "javers"
     }

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
@@ -37,16 +37,22 @@ abstract class JaversSqlRepositoryE2ETest extends JaversRepositoryShadowE2ETest 
         connection
     }
 
-    @Override
     def setup() {
         clearTables()
     }
 
     def cleanup() {
         connections.each {
-            it.rollback()
-            it.close()
+            if (it.isValid(1)) {
+                it.commit()
+                it.close()
+            }
         }
+    }
+
+    @Override
+    void databaseCommit() {
+        getConnection().commit();
     }
 
     @Override

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/JaversSqlRepositoryE2ETest.groovy
@@ -44,7 +44,7 @@ abstract class JaversSqlRepositoryE2ETest extends JaversRepositoryShadowE2ETest 
     def cleanup() {
         connections.each {
             if (it.isValid(1)) {
-                it.commit()
+                it.rollback()
                 it.close()
             }
         }

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/docker/MySqlDockerIntegrationTest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/docker/MySqlDockerIntegrationTest.groovy
@@ -1,0 +1,32 @@
+package org.javers.repository.sql.integration.docker
+
+import org.javers.repository.sql.DialectName
+import org.javers.repository.sql.JaversSqlRepositoryE2ETest
+import org.junit.ClassRule
+import org.testcontainers.containers.MySQLContainer
+import spock.lang.Shared
+
+import java.sql.Connection
+import java.sql.DriverManager
+
+class MySqlDockerIntegrationTest extends JaversSqlRepositoryE2ETest {
+
+    @ClassRule @Shared
+    public MySQLContainer postgres = new MySQLContainer()
+
+    Connection createConnection() {
+       String url = postgres.jdbcUrl
+       String user = postgres.username
+       String pass = postgres.password
+
+       DriverManager.getConnection(url, user, pass)
+    }
+
+    DialectName getDialect() {
+        DialectName.MYSQL
+    }
+
+    String getSchema() {
+        return null
+    }
+}

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/MySqlIntegrationTest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/MySqlIntegrationTest.groovy
@@ -8,14 +8,17 @@ import java.sql.DriverManager
 
 class MySqlIntegrationTest extends JaversSqlRepositoryE2ETest {
 
+    @Override
     Connection createConnection() {
         DriverManager.getConnection("jdbc:mysql://localhost/travis_ci_test", "javers", "javers");
     }
 
+    @Override
     DialectName getDialect() {
         DialectName.MYSQL
     }
 
+    @Override
     String getSchema() {
         return null
     }

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/MySqlIntegrationWithSchemaTest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/MySqlIntegrationWithSchemaTest.groovy
@@ -7,6 +7,7 @@ import spock.lang.Ignore
  */
 @Ignore // in MySQL SCHEMA is a synonym for DATABASE
 class MySqlIntegrationWithSchemaTest extends MySqlIntegrationTest {
+    @Override
     String getSchema() {
         return "travis_ci_test"
     }

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/PostgreSqlIntegrationTest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/PostgreSqlIntegrationTest.groovy
@@ -8,15 +8,23 @@ import java.sql.DriverManager
 
 class PostgreSqlIntegrationTest extends JaversSqlRepositoryE2ETest {
 
+    @Override
     Connection createConnection() {
         DriverManager.getConnection("jdbc:postgresql://localhost:5432/travis_ci_test", "javers", "javers");
     }
 
+    @Override
     DialectName getDialect() {
         DialectName.POSTGRES
     }
 
+    @Override
     String getSchema() {
         return null
+    }
+
+    @Override
+    boolean useRandomCommitIdGenerator() {
+        false
     }
 }

--- a/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/PostgreSqlIntegrationWithSchemaTest.groovy
+++ b/javers-persistence-sql/src/test/groovy/org/javers/repository/sql/integration/opendatabases/PostgreSqlIntegrationWithSchemaTest.groovy
@@ -5,6 +5,7 @@ package org.javers.repository.sql.integration.opendatabases
  */
 class PostgreSqlIntegrationWithSchemaTest extends PostgreSqlIntegrationTest {
 
+    @Override
     String getSchema() {
         return "j_some"
     }


### PR DESCRIPTION
better test for concurrent writes from many Javers instances to the same DB