### PR TITLE
#962 Replace references to legacy MongoClient with newer version.

### DIFF
--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/EmbeddedMongoE2ETest.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/EmbeddedMongoE2ETest.groovy
@@ -1,6 +1,6 @@
 package org.javers.repository.mongo
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoDatabase
 import spock.lang.Shared
 

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/EmbeddedMongoFactory.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/EmbeddedMongoFactory.groovy
@@ -1,6 +1,7 @@
 package org.javers.repository.mongo
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoClients
 import de.flapdoodle.embed.mongo.MongodExecutable
 import de.flapdoodle.embed.mongo.MongodProcess
 import de.flapdoodle.embed.mongo.MongodStarter
@@ -26,7 +27,7 @@ class EmbeddedMongoFactory {
                     .net(new Net(BIND_IP, port, Network.localhostIsIPv6()))
                     .build())
             mongodExecutable.start()
-            mongoClient = new MongoClient(BIND_IP, port)
+            mongoClient = MongoClients.create("mongodb://$BIND_IP:$port")
         }
 
         MongoClient getClient () {

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/NewMongoPerformanceTest.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/NewMongoPerformanceTest.groovy
@@ -1,6 +1,6 @@
 package org.javers.repository.mongo
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClients
 import org.javers.repository.jql.NewPerformanceTest
 import spock.lang.Ignore
 
@@ -10,7 +10,7 @@ import static org.javers.core.JaversBuilder.javers
 class NewMongoPerformanceTest extends NewPerformanceTest {
 
     def setup() {
-        def mongoRepository = new MongoRepository(new MongoClient().getDatabase("j_int_test"))
+        def mongoRepository = new MongoRepository(MongoClients.create().getDatabase("j_int_test"))
         javers = javers().registerJaversRepository(mongoRepository).build()
     }
 }

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/cases/CrossReferenceTest.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/cases/CrossReferenceTest.groovy
@@ -1,6 +1,6 @@
 package org.javers.repository.mongo.cases
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoDatabase
 import org.javers.core.JaversBuilder
 import org.javers.core.metamodel.annotation.DiffIgnore

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/cases/MapKeyDotReplacerTest.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/cases/MapKeyDotReplacerTest.groovy
@@ -1,5 +1,7 @@
 package org.javers.repository.mongo.cases
 
+import com.mongodb.client.MongoClient
+
 import static org.javers.repository.jql.QueryBuilder.byInstanceId
 
 import javax.persistence.Id
@@ -8,7 +10,6 @@ import org.javers.core.JaversBuilder
 import org.javers.repository.mongo.EmbeddedMongoFactory
 import org.javers.repository.mongo.MongoRepository
 
-import com.mongodb.MongoClient
 import com.mongodb.client.MongoDatabase
 
 import groovy.transform.EqualsAndHashCode

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/integration/MongoIntegrationTest.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/integration/MongoIntegrationTest.groovy
@@ -1,6 +1,6 @@
 package org.javers.repository.mongo.integration
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoDatabase
 import org.javers.repository.mongo.JaversMongoRepositoryE2ETest
 
@@ -13,6 +13,6 @@ class MongoIntegrationTest extends JaversMongoRepositoryE2ETest {
 
     @Override
     protected MongoDatabase getMongoDb() {
-        new MongoClient('localhost', 27017).getDatabase("j_int_test")
+        MongoClients.create("mongodb://localhost:27017").getDatabase("j_int_test")
     }
 }

--- a/javers-spring-boot-starter-mongo/README.md
+++ b/javers-spring-boot-starter-mongo/README.md
@@ -47,15 +47,12 @@ If greater control is required over how Javers configures the `MongoClient` inst
 you can configure a `MongoClientOptions` bean named `javersMongoClientOptions`.
 If there is no such bean, default client options are used. 
 
-For example, if you want to enable SSL and set socket timeout value,
+For example, to configure the MongoClient with custom parameters,
 define this bean:
 
 ```java
-@Bean("javersMongoClientOptions")
-public MongoClientOptions clientOptions() {
-    return MongoClientOptions.builder()
-    .sslEnabled(true)
-    .socketTimeout(1500)
-    .build();
+@Bean("javersMongoClientSettings")
+public MongoClientSettings clientSettings() {
+    return MongoClientSetting.builder().build();
 }
 ```

--- a/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversDedicatedMongoFactory.java
+++ b/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversDedicatedMongoFactory.java
@@ -46,7 +46,8 @@ class JaversDedicatedMongoFactory {
             if (credentials != null)
                 mongoClient = MongoClients.create(builder(settings).credential(credentials).build());
             else
-                mongoClient = MongoClients.create(builder(settings).applyConnectionString(new ConnectionString(serverAddress.toString())).build());
+                mongoClient = MongoClients.create(builder(settings)
+                        .applyConnectionString(new ConnectionString("mongodb://" + serverAddress.toString())).build());
             return mongoClient.getDatabase(properties.getMongodb().getDatabase());
         }
 

--- a/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversDedicatedMongoFactory.java
+++ b/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversDedicatedMongoFactory.java
@@ -1,43 +1,52 @@
 package org.javers.spring.boot.mongo;
 
 
-import com.mongodb.*;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import org.javers.common.exception.JaversException;
 import org.javers.common.exception.JaversExceptionCode;
 
-import java.util.Collections;
-import java.util.List;
+import javax.annotation.Nullable;
 import java.util.Optional;
+
+import static com.mongodb.MongoClientSettings.builder;
 
 /**
  * Helper class for creating {@code MongoClient} based on Javers MongoDB properties.
+ *
  * @see {@linkplain org.springframework.boot.autoconfigure.mongo.MongoClientFactory}
  */
 class JaversDedicatedMongoFactory {
     private static String DEFAULT_HOST = "localhost";
     private static int DEFAULT_PORT = 27017;
 
-    static MongoDatabase createMongoDatabase(JaversMongoProperties properties, Optional<MongoClientOptions> mongoClientOptions) {
-        MongoClientOptions options = mongoClientOptions.orElse(MongoClientOptions.builder().build());
+    static MongoDatabase createMongoDatabase(JaversMongoProperties properties, @Nullable MongoClientSettings mongoClientSettings) {
+        final MongoClientSettings settings = Optional.ofNullable(mongoClientSettings)
+                .orElseGet(() -> builder().build());
 
-        if(properties.getMongodb().getUri() != null) {
-            MongoClientURI mongoClientURI = new MongoClientURI(properties.getMongodb().getUri());
-            MongoClient mongoClient = new MongoClient(mongoClientURI);
-            return mongoClient.getDatabase(mongoClientURI.getDatabase());
+        if (properties.getMongodb().getUri() != null) {
+            final ConnectionString connectionString = new ConnectionString(properties.getMongodb().getUri());
+            MongoClient mongoClient = MongoClients.create(connectionString);
+            return mongoClient.getDatabase(connectionString.getDatabase());
         }
         if (properties.getMongodb().getHost() != null) {
             String host = properties.getMongodb().getHost() == null ? DEFAULT_HOST
                     : properties.getMongodb().getHost();
             int port = properties.getMongodb().getPort() == null ? DEFAULT_PORT
                     : properties.getMongodb().getPort();
-            List<ServerAddress> hosts = Collections
-                    .singletonList(new ServerAddress(host, port));
+            ServerAddress serverAddress = new ServerAddress(host, port);
 
             MongoCredential credentials = getCredentials(properties);
-            MongoClient mongoClient = (credentials != null)
-                    ? new MongoClient(hosts, credentials, options)
-                    : new MongoClient(hosts, options);
+            MongoClient mongoClient;
+            if (credentials != null)
+                mongoClient = MongoClients.create(builder(settings).credential(credentials).build());
+            else
+                mongoClient = MongoClients.create(builder(settings).applyConnectionString(new ConnectionString(serverAddress.toString())).build());
             return mongoClient.getDatabase(properties.getMongodb().getDatabase());
         }
 

--- a/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoAutoConfiguration.java
+++ b/javers-spring-boot-starter-mongo/src/main/java/org/javers/spring/boot/mongo/JaversMongoAutoConfiguration.java
@@ -1,7 +1,7 @@
 package org.javers.spring.boot.mongo;
 
-import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;

--- a/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/JaversMongoStarterDedicatedMongoTest.groovy
+++ b/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/JaversMongoStarterDedicatedMongoTest.groovy
@@ -1,6 +1,6 @@
 package org.javers.spring.boot.mongo
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoDatabase
 import org.javers.core.Javers
 import org.javers.repository.jql.QueryBuilder
@@ -36,7 +36,7 @@ abstract class JaversMongoStarterDedicatedMongoTest extends Specification {
         javers.commit("a", dummyEntity)
         def snapshots = javers.findSnapshots(QueryBuilder.byInstance(dummyEntity).build())
 
-        MongoDatabase dedicatedDb = new MongoClient("localhost", PORT).getDatabase("javers-dedicated")
+        MongoDatabase dedicatedDb = MongoClients.create("mongodb://localhost:$PORT").getDatabase("javers-dedicated")
 
         then:
         snapshots.size() == 1

--- a/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/JaversMongoStarterDefaultsTest.groovy
+++ b/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/JaversMongoStarterDefaultsTest.groovy
@@ -1,6 +1,6 @@
 package org.javers.spring.boot.mongo
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoDatabase
 import org.javers.core.Javers
 import org.javers.repository.jql.QueryBuilder

--- a/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/config/MongoClientConfig.java
+++ b/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/config/MongoClientConfig.java
@@ -1,0 +1,16 @@
+package org.javers.spring.boot.mongo.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile(value = "test")
+public class MongoClientConfig {
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create();
+    }
+}

--- a/javers-spring-boot-starter-mongo/src/test/java/org/javers/spring/boot/mongo/config/MongoClientConfig.java
+++ b/javers-spring-boot-starter-mongo/src/test/java/org/javers/spring/boot/mongo/config/MongoClientConfig.java
@@ -4,10 +4,8 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile(value = "test")
 public class MongoClientConfig {
     @Bean
     public MongoClient mongoClient() {

--- a/javers-spring/src/test/groovy/org/javers/spring/auditable/integration/EmbeddedMongoFactory.groovy
+++ b/javers-spring/src/test/groovy/org/javers/spring/auditable/integration/EmbeddedMongoFactory.groovy
@@ -1,6 +1,7 @@
 package org.javers.spring.auditable.integration
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoClients
 import de.flapdoodle.embed.mongo.MongodExecutable
 import de.flapdoodle.embed.mongo.MongodStarter
 import de.flapdoodle.embed.mongo.config.IMongodConfig
@@ -28,7 +29,7 @@ class EmbeddedMongoFactory {
         EmbeddedMongo () {
             mongodExecutable = starter.prepare(mongodConfig)
             mongodExecutable.start()
-            mongoClient = new MongoClient(BIND_IP, PORT)
+            mongoClient = MongoClients.create("mongodb://$BIND_IP:$PORT")
         }
 
         MongoClient getClient () {

--- a/javers-spring/src/test/groovy/org/javers/spring/auditable/integration/TestApplicationConfig.groovy
+++ b/javers-spring/src/test/groovy/org/javers/spring/auditable/integration/TestApplicationConfig.groovy
@@ -1,6 +1,6 @@
 package org.javers.spring.auditable.integration
 
-import com.mongodb.MongoClient
+import com.mongodb.client.MongoClient
 import org.javers.spring.auditable.CommitPropertiesProvider
 import org.javers.spring.example.JaversSpringMongoApplicationConfig
 import org.springframework.beans.factory.annotation.Autowired

--- a/javers-spring/src/test/java/org/javers/spring/example/JaversSpringMongoApplicationConfig.java
+++ b/javers-spring/src/test/java/org/javers/spring/example/JaversSpringMongoApplicationConfig.java
@@ -1,7 +1,8 @@
 package org.javers.spring.example;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import org.javers.common.collections.Maps;
 import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
@@ -56,7 +57,7 @@ public class JaversSpringMongoApplicationConfig {
     @Bean(name="realMongoClient")
     @ConditionalOnMissingBean
     public MongoClient mongo() {
-        return new MongoClient();
+        return MongoClients.create();
     }
 
     /**


### PR DESCRIPTION
- Replaced all the imports of `MongoClient` from `com.mongodb.MongoClient` to `com.mongodb.client.MongoClient`
- Using `MongoClients` from `com.mongodb.client` package to construct `MongoClient` which is now the recommended way.