### PR TITLE
#981 Adding @Order(0) to JaversSpringDataAuditableRepositoryAspect.

### DIFF
--- a/javers-spring/src/main/java/org/javers/spring/auditable/aspect/springdata/JaversSpringDataAuditableRepositoryAspect.java
+++ b/javers-spring/src/main/java/org/javers/spring/auditable/aspect/springdata/JaversSpringDataAuditableRepositoryAspect.java
@@ -7,6 +7,7 @@ import org.javers.core.Javers;
 import org.javers.spring.auditable.AuthorProvider;
 import org.javers.spring.auditable.CommitPropertiesProvider;
 
+import org.springframework.core.annotation.Order;
 import java.util.Map;
 
 /**
@@ -17,6 +18,7 @@ import java.util.Map;
  * Calls {@link Javers#commitShallowDelete(String, Object, Map)} on arguments passed to delete() methods.
  */
 @Aspect
+@Order(0)
 public class JaversSpringDataAuditableRepositoryAspect extends AbstractSpringAuditableRepositoryAspect {
     public JaversSpringDataAuditableRepositoryAspect(Javers javers, AuthorProvider authorProvider, CommitPropertiesProvider commitPropertiesProvider) {
         super(javers, authorProvider, commitPropertiesProvider);


### PR DESCRIPTION
Adding @order(0) to JaversSpringDataAuditableRepositoryAspect.
Why ?
This aspect contains advices that run for all save/delete operations in
the application but since there is no order present with it. It takes
the default order which is highest precedence as it is using after-
advices. So giving it order 0 would help if some other advice needed to
execute before this.
That's why explicitly giving it 0.