### PR TITLE
Abandoned connections in schema manager

### DIFF
--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
@@ -152,8 +152,8 @@ public class JaversSchemaManager extends SchemaNameAware {
     }
 
     private boolean executeSQL(String sql) {
-        try {
-            Statement stmt = connectionProvider.getConnection().createStatement();
+        try (Connection connection = connectionProvider.getConnection()) {
+            Statement stmt = connection.createStatement();
 
             logger.info("executing schema migration SQL:\n" + sql);
 


### PR DESCRIPTION
This method was causing a connection leak due to opened connection wasn't closed.
This was mentioned in #576.