### PR TITLE
Handle Composite id with IdClass annotation

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/type/InstanceIdFactory.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/InstanceIdFactory.java
@@ -51,7 +51,12 @@ class InstanceIdFactory {
                     .entrySet()
                     .stream()
                     .sorted(Map.Entry.comparingByKey())
-                    .map(e -> localIdAsString(entityType.getProperty(e.getKey()), e.getValue()))
+                    .map(e -> {
+                        JaversProperty idProperty = entityType.getProperty(e.getKey());
+                        Object dehydratedAtomicLocalId = dehydratedLocalId(idProperty, e.getValue());
+
+                        return localIdAsString(idProperty, dehydratedAtomicLocalId);
+                    })
                     .collect(Collectors.toList()));
         }
 


### PR DESCRIPTION
When using the IdClass annotation and using the Entities as the Id property javers should only reference the inner id fields instead of using the toString on the object.
With the dehydrate it will only store the Id property of the referenced entity in the InstanceId.

Referenced from: #1077 