### PR TITLE
Fixes #1108: Allow deleting inexistent object from repository.

### DIFF
--- a/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
+++ b/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
@@ -53,9 +53,7 @@ public class CommitFactory {
         Optional<CdoSnapshot> previousSnapshot = javersRepository.getLatest(removedId);
 
         CommitMetadata commitMetadata = newCommitMetadata(author, properties);
-        CdoSnapshot terminalSnapshot = previousSnapshot
-                .map(prev -> snapshotFactory.createTerminal(removedId, prev, commitMetadata))
-                .orElseThrow(() -> new JaversException(JaversExceptionCode.CANT_DELETE_OBJECT_NOT_FOUND, removedId.value()));
+        CdoSnapshot terminalSnapshot = snapshotFactory.createTerminal(removedId, previousSnapshot.orElse(null), commitMetadata);
         Diff diff = diffFactory.singleTerminal(removedId, commitMetadata);
         return new Commit(commitMetadata, Lists.asList(terminalSnapshot), diff);
     }

--- a/javers-core/src/main/java/org/javers/core/snapshot/SnapshotFactory.java
+++ b/javers-core/src/main/java/org/javers/core/snapshot/SnapshotFactory.java
@@ -35,7 +35,7 @@ public class SnapshotFactory {
                 .withManagedType(managedType)
                 .withCommitMetadata(commitMetadata)
                 .withType(TERMINAL)
-                .withVersion(previous.getVersion()+1)
+                .withVersion(previous != null ? (previous.getVersion() + 1) : 1)
                 .build();
     }
 

--- a/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
@@ -115,17 +115,20 @@ class JaversCommitE2ETest extends Specification {
         opType << ["using object instance","using globalId"]
     }
 
-    def "should fail when deleting non existing object"() {
+    def "should create terminal commit when deleting non existing object"() {
         given:
         def javers = javers().build()
         def anEntity = new SnapshotEntity(id:1)
 
         when:
-        javers.commitShallowDelete("some.login", anEntity)
+        def commit = javers.commitShallowDelete("some.login", anEntity)
 
         then:
-        JaversException exception = thrown()
-        exception.code == JaversExceptionCode.CANT_DELETE_OBJECT_NOT_FOUND
+        CommitAssert.assertThat(commit)
+                .hasId("1.00")
+                .hasObjectRemoved(instanceId(1,SnapshotEntity))
+                .hasSnapshots(1)
+                .hasTerminalSnapshot(instanceId(1,SnapshotEntity))
     }
 
     def "should create initial commit for new objects"() {

--- a/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotFactoryTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotFactoryTest.groovy
@@ -332,4 +332,17 @@ class SnapshotFactoryTest extends Specification{
     def someCommitMetadata(){
         new CommitMetadata("kazik", [:], LocalDateTime.now(), null, new CommitId(1, 0))
     }
+
+    def "should create terminal snapshot when deleting an inexistent object from repository"() {
+        given:
+        def cdo = new SnapshotEntity(id:1)
+        def node = javers.createLiveNode(cdo)
+        def id = javers.instanceId(cdo)
+
+        when:
+        def snapshot = snapshotFactory.createTerminal(id, null, someCommitMetadata())
+
+        then:
+        snapshot.version == 1L
+    }
 }


### PR DESCRIPTION
When trying to delete an inexistent object from a repository instead of
throwing an exception, create a terminal commit for the given object, as
version 1.