### PR TITLE
Fix #1168 Incorrect sequence SQL for H2 v2

### DIFF
--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/session/Dialects.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/session/Dialects.java
@@ -35,7 +35,7 @@ class Dialects {
 
         @Override
         KeyGeneratorDefinition getKeyGeneratorDefinition() {
-            return (SequenceDefinition) seqName ->  seqName + ".nextval";
+            return (SequenceDefinition) seqName ->  "NEXT VALUE FOR " + seqName;
         }
     }
 


### PR DESCRIPTION
This reproduces the bug in #1168 by updating H2 to 2.1.210 which is good any was as earlier versions have known exploits https://mvnrepository.com/artifact/com.h2database/h2.

As recommended in H2 migration to v2 docs http://www.h2database.com/html/migration-to-v2.html this switches to sequence value expression https://h2database.com/html/grammar.html#sequence_value_expression

This is backwards compatible with H2 v1