### PR TITLE
Bug when comparing nested objects

### DIFF
--- a/javers-core/src/main/java/org/javers/core/CoreConfiguration.java
+++ b/javers-core/src/main/java/org/javers/core/CoreConfiguration.java
@@ -23,11 +23,14 @@ public class CoreConfiguration {
 
     private final boolean terminalChanges;
 
+    private final boolean usePrimitiveDefaults;
+
     private final CommitIdGenerator commitIdGenerator;
 
     private final Supplier<CommitId> customCommitIdGenerator;
 
-    CoreConfiguration(PrettyValuePrinter prettyValuePrinter, MappingStyle mappingStyle, ListCompareAlgorithm listCompareAlgorithm, boolean initialChanges, CommitIdGenerator commitIdGenerator, Supplier<CommitId> customCommitIdGenerator, boolean terminalChanges, boolean prettyPrint) {
+    CoreConfiguration(PrettyValuePrinter prettyValuePrinter, MappingStyle mappingStyle, ListCompareAlgorithm listCompareAlgorithm, boolean initialChanges, CommitIdGenerator commitIdGenerator, Supplier<CommitId> customCommitIdGenerator, boolean terminalChanges, boolean prettyPrint,
+            boolean usePrimitiveDefaults) {
         this.prettyValuePrinter = prettyValuePrinter;
         this.mappingStyle = mappingStyle;
         this.listCompareAlgorithm = listCompareAlgorithm;
@@ -36,6 +39,7 @@ public class CoreConfiguration {
         this.customCommitIdGenerator = customCommitIdGenerator;
         this.terminalChanges = terminalChanges;
         this.prettyPrint = prettyPrint;
+        this.usePrimitiveDefaults = usePrimitiveDefaults;
     }
 
     public PrettyValuePrinter getPrettyValuePrinter() {
@@ -52,6 +56,10 @@ public class CoreConfiguration {
 
     public boolean isInitialChanges() {
         return initialChanges;
+    }
+
+    public boolean getUsePrimitiveDefaults() {
+        return usePrimitiveDefaults;
     }
 
     public boolean isTerminalChanges() {

--- a/javers-core/src/main/java/org/javers/core/CoreConfigurationBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/CoreConfigurationBuilder.java
@@ -20,6 +20,8 @@ class CoreConfigurationBuilder {
 
     private boolean terminalChanges = true;
 
+    private boolean usePrimitiveDefaults = true;
+
     private CommitIdGenerator commitIdGenerator = CommitIdGenerator.SYNCHRONIZED_SEQUENCE;
 
     private Supplier<CommitId> customCommitIdGenerator;
@@ -40,8 +42,9 @@ class CoreConfigurationBuilder {
                 commitIdGenerator,
                 customCommitIdGenerator,
                 terminalChanges,
-                prettyPrint
-                );
+                prettyPrint,
+                usePrimitiveDefaults
+        );
     }
 
     CoreConfigurationBuilder withPrettyPrint(boolean prettyPrint) {
@@ -77,6 +80,11 @@ class CoreConfigurationBuilder {
 
     CoreConfigurationBuilder withTerminalChanges(boolean terminalChanges) {
         this.terminalChanges = terminalChanges;
+        return this;
+    }
+
+    CoreConfigurationBuilder withUsePrimitiveDefaults(boolean usePrimitiveDefaults) {
+        this.usePrimitiveDefaults = usePrimitiveDefaults;
         return this;
     }
 

--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -2,7 +2,7 @@ package org.javers.core;
 
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
-import org.javers.common.collections.Lists;
+
 import org.javers.common.date.DateProvider;
 import org.javers.common.date.DefaultDateProvider;
 import org.javers.common.validation.Validate;
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -78,10 +79,12 @@ import static org.javers.common.validation.Validate.argumentsAreNotNull;
  *                              .build();
  * </pre>
  *
- * @see <a href="http://javers.org/documentation/domain-configuration/">http://javers.org/documentation/domain-configuration</a>
  * @author bartosz walacik
+ * @see <a
+ * href="http://javers.org/documentation/domain-configuration/">http://javers.org/documentation/domain-configuration</a>
  */
 public class JaversBuilder extends AbstractContainerBuilder {
+
     public static final Logger logger = LoggerFactory.getLogger(JaversBuilder.class);
 
     private final Map<Class, ClientsClassDefinition> clientsClassDefinitions = new LinkedHashMap<>();
@@ -91,6 +94,8 @@ public class JaversBuilder extends AbstractContainerBuilder {
     private final Set<Class> classesToScan = new HashSet<>();
 
     private final Set<ConditionalTypesPlugin> conditionalTypesPlugins;
+
+    private boolean usePrimitiveDefaults = true;
 
     private CoreConfigurationBuilder coreConfigurationBuilder = CoreConfigurationBuilder.coreConfiguration();
     private JaversRepository repository;
@@ -115,7 +120,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
         if (isClassPresent("groovy.lang.MetaClass")) {
             conditionalTypesPlugins.add(new GroovyAddOns());
         }
-        if (isClassPresent("org.joda.time.LocalDate")){
+        if (isClassPresent("org.joda.time.LocalDate")) {
             conditionalTypesPlugins.add(new JodaAddOns());
         }
         if (isClassPresent("com.google.common.collect.Multimap")) {
@@ -142,8 +147,9 @@ public class JaversBuilder extends AbstractContainerBuilder {
         return javers;
     }
 
-    protected Javers assembleJaversInstance(){
-        CoreConfiguration coreConfiguration = configurationBuilder().build();
+    protected Javers assembleJaversInstance() {
+        CoreConfiguration coreConfiguration = configurationBuilder().withUsePrimitiveDefaults(usePrimitiveDefaults)
+                .build();
         addComponent(coreConfiguration);
 
         // boot main modules
@@ -170,7 +176,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
         bootDateTimeProvider();
 
         // clases to scan & additionalTypes
-        for (Class c : classesToScan){
+        for (Class c : classesToScan) {
             typeMapper().getJaversType(c);
         }
         typeMapper().addPluginTypes(additionalTypes);
@@ -183,7 +189,8 @@ public class JaversBuilder extends AbstractContainerBuilder {
     }
 
     /**
-     * @see <a href="http://javers.org/documentation/repository-configuration">http://javers.org/documentation/repository-configuration</a>
+     * @see <a
+     * href="http://javers.org/documentation/repository-configuration">http://javers.org/documentation/repository-configuration</a>
      */
     public JaversBuilder registerJaversRepository(JaversRepository repository) {
         argumentsAreNotNull(repository);
@@ -206,7 +213,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      */
     public JaversBuilder registerEntity(Class<?> entityClass) {
         argumentIsNotNull(entityClass);
-        return registerEntity( new EntityDefinition(entityClass));
+        return registerEntity(new EntityDefinition(entityClass));
     }
 
     /**
@@ -250,7 +257,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * @see <a href="http://javers.org/documentation/domain-configuration/#entity">http://javers.org/documentation/domain-configuration/#entity</a>
      * @see EntityDefinitionBuilder#entityDefinition(Class)
      */
-    public JaversBuilder registerEntity(EntityDefinition entityDefinition){
+    public JaversBuilder registerEntity(EntityDefinition entityDefinition) {
         argumentIsNotNull(entityDefinition);
         return registerType(entityDefinition);
     }
@@ -339,14 +346,19 @@ public class JaversBuilder extends AbstractContainerBuilder {
 
         long start = System.currentTimeMillis();
         logger.info("scanning package(s): {}", packagesToScan);
-        List<Class<?>> scan = findClasses(TypeName.class, packagesToScan.replaceAll(" ","").split(","));
-		for (Class<?> c : scan) {
-			scanTypeName(c);
-		}
-		long delta = System.currentTimeMillis() - start;
+        List<Class<?>> scan = findClasses(TypeName.class, packagesToScan.replaceAll(" ", "").split(","));
+        for (Class<?> c : scan) {
+            scanTypeName(c);
+        }
+        long delta = System.currentTimeMillis() - start;
         logger.info("  found {} ManagedClass(es) with @TypeName in {} ms", scan.size(), delta);
 
-		return this;
+        return this;
+    }
+
+    public JaversBuilder whithUsePrimitiveDefaults(boolean usePrimitiveDefaults) {
+        this.usePrimitiveDefaults = usePrimitiveDefaults;
+        return this;
     }
 
     /**
@@ -362,7 +374,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      *
      * @since 1.4
      */
-    public JaversBuilder scanTypeName(Class userType){
+    public JaversBuilder scanTypeName(Class userType) {
         classesToScan.add(userType);
         return this;
     }
@@ -443,14 +455,14 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * @since 5.8
      */
     public <T> JaversBuilder registerValue(Class<T> valueClass,
-                                           BiFunction<T, T, Boolean> equalsFunction,
-                                           Function<T, String> toStringFunction) {
+            BiFunction<T, T, Boolean> equalsFunction,
+            Function<T, String> toStringFunction) {
         Validate.argumentsAreNotNull(valueClass, equalsFunction, toStringFunction);
 
         return registerValue(valueClass, new CustomValueComparator<T>() {
             @Override
             public boolean equals(T a, T b) {
-                return equalsFunction.apply(a,b);
+                return equalsFunction.apply(a, b);
             }
 
             @Override
@@ -478,7 +490,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
         return registerValue(valueClass, new CustomValueComparator<T>() {
             @Override
             public boolean equals(T a, T b) {
-                return equalsFunction.apply(a,b);
+                return equalsFunction.apply(a, b);
             }
 
             @Override
@@ -497,7 +509,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
     @Deprecated
     public <T> JaversBuilder registerValueWithCustomToString(Class<T> valueClass, Function<T, String> toStringFunction) {
         Validate.argumentsAreNotNull(valueClass, toStringFunction);
-        return registerValue(valueClass, (a,b) -> Objects.equals(a,b), toStringFunction);
+        return registerValue(valueClass, (a, b) -> Objects.equals(a, b), toStringFunction);
     }
 
     /**
@@ -547,7 +559,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * @see JsonTypeAdapter
      */
     public JaversBuilder registerValueTypeAdapter(JsonTypeAdapter typeAdapter) {
-        for (Class c : (List<Class>)typeAdapter.getValueTypes()){
+        for (Class c : (List<Class>) typeAdapter.getValueTypes()) {
             registerValue(c);
         }
 
@@ -623,14 +635,14 @@ public class JaversBuilder extends AbstractContainerBuilder {
     }
 
     public JaversBuilder registerEntities(Class<?>... entityClasses) {
-        for(Class clazz : entityClasses) {
+        for (Class clazz : entityClasses) {
             registerEntity(clazz);
         }
         return this;
     }
 
     public JaversBuilder registerValueObjects(Class<?>... valueObjectClasses) {
-        for(Class clazz : valueObjectClasses) {
+        for (Class clazz : valueObjectClasses) {
             registerValueObject(clazz);
         }
         return this;
@@ -694,7 +706,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * </pre>
      * @see NewObject
      */
-    public JaversBuilder withInitialChanges(boolean initialChanges){
+    public JaversBuilder withInitialChanges(boolean initialChanges) {
         configurationBuilder().withInitialChanges(initialChanges);
         return this;
     }
@@ -703,7 +715,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * Use {@link #withInitialChanges(boolean)}
      */
     @Deprecated
-    public JaversBuilder withNewObjectsSnapshot(boolean newObjectsSnapshot){
+    public JaversBuilder withNewObjectsSnapshot(boolean newObjectsSnapshot) {
         return this.withInitialChanges(newObjectsSnapshot);
     }
 
@@ -730,7 +742,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * @since 6.0
      * @see ObjectRemoved
      */
-    public JaversBuilder withTerminalChanges(boolean terminalChanges){
+    public JaversBuilder withTerminalChanges(boolean terminalChanges) {
         configurationBuilder().withTerminalChanges(terminalChanges);
         return this;
     }
@@ -758,7 +770,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * @param <T> Custom Type
      * @see <a href="https://javers.org/documentation/diff-configuration/#custom-comparators">https://javers.org/documentation/diff-configuration/#custom-comparators</a>
      */
-    public <T> JaversBuilder registerCustomType(Class<T> customType, CustomPropertyComparator<T, ?> comparator){
+    public <T> JaversBuilder registerCustomType(Class<T> customType, CustomPropertyComparator<T, ?> comparator) {
         registerType(new CustomDefinition(customType, comparator));
         bindComponent(comparator, new CustomToNativeAppenderAdapter(comparator, customType));
         return this;
@@ -768,7 +780,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * @deprecated Renamed to {@link #registerCustomType(Class, CustomPropertyComparator)}
      */
     @Deprecated
-    public <T> JaversBuilder registerCustomComparator(CustomPropertyComparator<T, ?> comparator, Class<T> customType){
+    public <T> JaversBuilder registerCustomComparator(CustomPropertyComparator<T, ?> comparator, Class<T> customType) {
         return registerCustomType(customType, comparator);
     }
 
@@ -851,14 +863,14 @@ public class JaversBuilder extends AbstractContainerBuilder {
     }
 
     private TypeMapperLazy typeMapperLazy() {
-        return (TypeMapperLazy)typeMapper();
+        return (TypeMapperLazy) typeMapper();
     }
 
     private CoreConfigurationBuilder configurationBuilder() {
         return this.coreConfigurationBuilder;
     }
 
-    private JsonConverterBuilder jsonConverterBuilder(){
+    private JsonConverterBuilder jsonConverterBuilder() {
         return getContainerComponent(JsonConverterBuilder.class);
     }
 
@@ -866,7 +878,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
         Set<JaversType> additionalTypes = new HashSet<>();
 
         for (ConditionalTypesPlugin plugin : conditionalTypesPlugins) {
-            logger.info("loading "+plugin.getClass().getSimpleName()+" ...");
+            logger.info("loading " + plugin.getClass().getSimpleName() + " ...");
 
             plugin.beforeAssemble(this);
 
@@ -906,16 +918,16 @@ public class JaversBuilder extends AbstractContainerBuilder {
         addComponent(dateProvider);
     }
 
-    private void bootRepository(){
+    private void bootRepository() {
         CoreConfiguration coreConfiguration = coreConfiguration();
         if (repository == null){
             logger.info("using fake InMemoryRepository, register actual Repository implementation via JaversBuilder.registerJaversRepository()");
             repository = new InMemoryRepository();
         }
 
-        repository.setJsonConverter( getContainerComponent(JsonConverter.class));
+        repository.setJsonConverter(getContainerComponent(JsonConverter.class));
 
-        if (repository instanceof ConfigurationAware){
+        if (repository instanceof ConfigurationAware) {
             ((ConfigurationAware) repository).setConfiguration(coreConfiguration);
         }
 
@@ -926,7 +938,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
     }
 
     private <T extends ClientsClassDefinition> T getClassDefinition(Class<?> baseJavaClass) {
-        return (T)clientsClassDefinitions.get(baseJavaClass);
+        return (T) clientsClassDefinitions.get(baseJavaClass);
     }
 
     private CoreConfiguration coreConfiguration() {

--- a/javers-core/src/main/java/org/javers/core/diff/DiffFactory.java
+++ b/javers-core/src/main/java/org/javers/core/diff/DiffFactory.java
@@ -44,7 +44,7 @@ public class DiffFactory {
         this.javersCoreConfiguration = javersCoreConfiguration;
 
         //sort by priority
-        Collections.sort(propertyChangeAppender, (p1, p2) -> ((Integer)p1.priority()).compareTo(p2.priority()));
+        Collections.sort(propertyChangeAppender, (p1, p2) -> ((Integer) p1.priority()).compareTo(p2.priority()));
         this.propertyChangeAppender = propertyChangeAppender;
     }
 
@@ -70,7 +70,7 @@ public class DiffFactory {
         return createAndAppendChanges(graphPair);
     }
 
-    public Diff singleTerminal(GlobalId removedId, CommitMetadata commitMetadata){
+    public Diff singleTerminal(GlobalId removedId, CommitMetadata commitMetadata) {
         Validate.argumentsAreNotNull(removedId, commitMetadata);
 
         DiffBuilder diff = new DiffBuilder(javersCoreConfiguration.getPrettyValuePrinter());
@@ -95,7 +95,7 @@ public class DiffFactory {
         }
 
         JaversType jType = typeMapper.getJaversType(handle.getClass());
-        if (jType instanceof ValueType || jType instanceof PrimitiveType){
+        if (jType instanceof ValueType || jType instanceof PrimitiveType) {
             throw new JaversException(JaversExceptionCode.COMPARING_TOP_LEVEL_VALUES_NOT_SUPPORTED,
                     jType.getClass().getSimpleName(), handle.getClass().getSimpleName());
         }
@@ -116,14 +116,18 @@ public class DiffFactory {
         //calculate snapshot of NewObjects and RemovedObjects
         if (javersCoreConfiguration.isInitialChanges()) {
             for (ObjectNode node : graphPair.getOnlyOnRight()) {
-                NodePair pair = new NodePair(new FakeNode(node.getCdo()), node, graphPair.getCommitMetadata());
+                NodePair pair = new NodePair(
+                        new FakeNode(node.getCdo(), javersCoreConfiguration.getUsePrimitiveDefaults()), node,
+                        graphPair.getCommitMetadata());
                 appendPropertyChanges(diff, pair);
             }
         }
 
         if (javersCoreConfiguration.isTerminalChanges()) {
             for (ObjectNode node : graphPair.getOnlyOnLeft()) {
-                NodePair pair = new NodePair(node, new FakeNode(node.getCdo()), graphPair.getCommitMetadata());
+                NodePair pair = new NodePair(node,
+                        new FakeNode(node.getCdo(), javersCoreConfiguration.getUsePrimitiveDefaults()),
+                        graphPair.getCommitMetadata());
                 appendPropertyChanges(diff, pair);
             }
         }
@@ -154,7 +158,7 @@ public class DiffFactory {
 
     private void appendChanges(DiffBuilder diff, NodePair pair, JaversProperty property, JaversType javersType) {
         for (PropertyChangeAppender appender : propertyChangeAppender) {
-            if (! appender.supports(javersType)){
+            if (!appender.supports(javersType)) {
                 continue;
             }
 

--- a/javers-core/src/main/java/org/javers/core/graph/FakeNode.java
+++ b/javers-core/src/main/java/org/javers/core/graph/FakeNode.java
@@ -12,8 +12,11 @@ import java.util.List;
 
 public class FakeNode extends ObjectNode<Cdo>{
 
-    public FakeNode(Cdo cdo) {
+    private boolean usePrimitiveDefaults;
+
+    public FakeNode(Cdo cdo, boolean usePrimitiveDefaults) {
         super(cdo);
+        this.usePrimitiveDefaults = usePrimitiveDefaults;
     }
 
     @Override
@@ -38,12 +41,18 @@ public class FakeNode extends ObjectNode<Cdo>{
 
     @Override
     public Object getPropertyValue(Property property) {
-        return Defaults.defaultValue(property.getGenericType());
+        if (this.usePrimitiveDefaults) {
+            return Defaults.defaultValue(property.getGenericType());
+        }
+        return null;
     }
 
     @Override
     public Object getDehydratedPropertyValue(JaversProperty property) {
-        return Defaults.defaultValue(property.getGenericType());
+        if (this.usePrimitiveDefaults) {
+            return Defaults.defaultValue(property.getGenericType());
+        }
+        return null;
     }
 
     @Override

--- a/javers-core/src/test/groovy/org/javers/core/nestedobjects/Item.java
+++ b/javers-core/src/test/groovy/org/javers/core/nestedobjects/Item.java
@@ -1,0 +1,11 @@
+package org.javers.core.nestedobjects;
+
+public class Item {
+
+    public int number;
+
+    Item(int number) {
+        this.number = number;
+    }
+}
+

--- a/javers-core/src/test/groovy/org/javers/core/nestedobjects/ItemParent.java
+++ b/javers-core/src/test/groovy/org/javers/core/nestedobjects/ItemParent.java
@@ -1,0 +1,14 @@
+package org.javers.core.nestedobjects;
+
+public class ItemParent {
+
+    public Item item;
+
+    ItemParent() {
+    }
+
+    ItemParent(Item item) {
+        this.item = item;
+    }
+
+}

--- a/javers-core/src/test/groovy/org/javers/core/nestedobjects/NestedObjectTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/nestedobjects/NestedObjectTest.groovy
@@ -1,0 +1,57 @@
+package org.javers.core.nestedobjects
+
+import org.javers.core.JaversBuilder
+import org.javers.core.diff.changetype.PropertyChange
+import spock.lang.Specification
+
+class NestedObjectTest extends Specification {
+    /*
+    When having two objects of which one has a child object, JaVers is not able to recognize the difference,
+    when the properties of the child object have the same values as the corresponding default value in
+    org.javers.common.collections.Defaults
+
+    The first test ends successful, because the child Item has the value property `1`, which differs from the default
+    in Defaults (0).
+
+    The second test fails, because the child Item has the value property `0`, which is the same as the default in
+    Defaults (0).
+
+    In both tests the itemParentA, which has a child Item is compared to the itemParentB, which has no child Item.
+
+    Please ensure, that removed nested objects are removed properly. I think the Problem is the FakeNode which uses the
+    defaults from Defaults in the methods getDehydratedPropertyValue and getPropertyValue.
+
+    The behaviour can be reproduced with other data types.
+    */
+    def javers = JaversBuilder.javers().build()
+
+    def "should recognize removed nested object a different value then Defaults.int.class"() {
+        given:
+        def item = new Item(1)
+        def itemParentA = new ItemParent(item)
+        def itemParentB = new ItemParent()
+
+        when:
+        def diff = javers.compare(itemParentA, itemParentB)
+
+        println (diff.prettyPrint())
+
+        then:
+        diff.getChangesByType(PropertyChange).size() == 1
+    }
+
+    def "should recognize removed nested object with same value as Defaults.int.class"() {
+        given:
+        def item = new Item(0)
+        def itemParentA = new ItemParent(item)
+        def itemParentB = new ItemParent()
+
+        when:
+        def diff = javers.compare(itemParentA, itemParentB)
+
+        println (diff.prettyPrint())
+
+        then:
+        diff.getChangesByType(PropertyChange).size() == 1
+    }
+}

--- a/javers-core/src/test/groovy/org/javers/core/nestedobjects/NestedObjectTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/nestedobjects/NestedObjectTest.groovy
@@ -23,10 +23,10 @@ class NestedObjectTest extends Specification {
 
     The behaviour can be reproduced with other data types.
     */
-    def javers = JaversBuilder.javers().build()
 
-    def "should recognize removed nested object a different value then Defaults.int.class"() {
+    def "should recognize removed nested object with a different value then Defaults.int.class with default ignoring config"() {
         given:
+        def javers = JaversBuilder.javers().whithUsePrimitiveDefaults(false).build()
         def item = new Item(1)
         def itemParentA = new ItemParent(item)
         def itemParentB = new ItemParent()
@@ -34,14 +34,15 @@ class NestedObjectTest extends Specification {
         when:
         def diff = javers.compare(itemParentA, itemParentB)
 
-        println (diff.prettyPrint())
+        println(diff.prettyPrint())
 
         then:
         diff.getChangesByType(PropertyChange).size() == 1
     }
 
-    def "should recognize removed nested object with same value as Defaults.int.class"() {
+    def "should recognize removed nested object with same value as Defaults.int.class with default ignoring config"() {
         given:
+        def javers = JaversBuilder.javers().whithUsePrimitiveDefaults(false).build()
         def item = new Item(0)
         def itemParentA = new ItemParent(item)
         def itemParentB = new ItemParent()
@@ -49,9 +50,74 @@ class NestedObjectTest extends Specification {
         when:
         def diff = javers.compare(itemParentA, itemParentB)
 
-        println (diff.prettyPrint())
+        println(diff.prettyPrint())
 
         then:
         diff.getChangesByType(PropertyChange).size() == 1
     }
+
+    def "should recognize added nested object with same value as Defaults.int.class with default ignoring config"() {
+        given:
+        def javers = JaversBuilder.javers().whithUsePrimitiveDefaults(false).build()
+        def item = new Item(0)
+        def itemParentA = new ItemParent()
+        def itemParentB = new ItemParent(item)
+
+        when:
+        def diff = javers.compare(itemParentA, itemParentB)
+
+        println(diff.prettyPrint())
+
+        then:
+        diff.getChangesByType(PropertyChange).size() == 1
+    }
+
+    def "should recognize removed nested object with a different value then Defaults.int.class with default config"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+        def item = new Item(1)
+        def itemParentA = new ItemParent(item)
+        def itemParentB = new ItemParent()
+
+        when:
+        def diff = javers.compare(itemParentA, itemParentB)
+
+        println(diff.prettyPrint())
+
+        then:
+        diff.getChangesByType(PropertyChange).size() == 1
+    }
+
+    def "should recognize removed nested object with same value as Defaults.int.class with default config"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+        def item = new Item(0)
+        def itemParentA = new ItemParent(item)
+        def itemParentB = new ItemParent()
+
+        when:
+        def diff = javers.compare(itemParentA, itemParentB)
+
+        println(diff.prettyPrint())
+
+        then:
+        diff.getChangesByType(PropertyChange).size() == 0
+    }
+
+    def "should recognize added nested object with same value as Defaults.int.class with default config"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+        def item = new Item(0)
+        def itemParentA = new ItemParent()
+        def itemParentB = new ItemParent(item)
+
+        when:
+        def diff = javers.compare(itemParentA, itemParentB)
+
+        println(diff.prettyPrint())
+
+        then:
+        diff.getChangesByType(PropertyChange).size() == 0
+    }
+
 }


### PR DESCRIPTION
    When having two objects of which one has a child object, JaVers is not able to recognize the difference,
    when the properties of the child object have the same values as the corresponding default value in
    org.javers.common.collections.Defaults
    The first test ends successful, because the child Item has the value property `1`, which differs from the default
    in Defaults (0).
    The second test fails, because the child Item has the value property `0`, which is the same as the default in
    Defaults (0).
    In both tests the itemParentA, which has a child Item is compared to the itemParentB, which has no child Item.
    Please ensure, that removed nested objects are removed properly. I think the Problem is the FakeNode which uses the
    defaults from Defaults in the methods getDehydratedPropertyValue and getPropertyValue.
    The behaviour can be reproduced with other data types.