### PR TITLE
Error while restarting the server using Postgres

### DIFF
--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/JaversSchemaManager.java
@@ -254,6 +254,7 @@ public class JaversSchemaManager extends SchemaNameAware {
                 } while(tableSchemaName != null
                         && !tableSchemaName.equalsIgnoreCase("public")
                         && !tableSchemaName.equals("")
+                        && (!(this.dialect instanceof PostgresDialect))
                         && (!(this.dialect instanceof MsSqlDialect) || !tableSchemaName.equalsIgnoreCase("dbo"))
                         && (!(this.dialect instanceof OracleDialect) || !tableSchemaName.equalsIgnoreCase("system"))
                 );


### PR DESCRIPTION
I have created the standalone spring boot application with the "Postgres" database. Whenever the server starts the first time all tables are getting appropriately created in the schema used by my application. When I restart the application getting an error as "ERROR: relation "jv_global_id" already exists". I checked the code "PgDatabaseMetaData" already skipping the system default namespace. so if we are getting results from the result set means we already have a table that exists in the Postgres database.
Note: Using "demo" as schema name but for others, it can be any random string.