### PR TITLE
fix deprecations for postgres and hibernate dialect

### DIFF
--- a/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/DialectMapper.java
+++ b/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/DialectMapper.java
@@ -15,10 +15,10 @@ public class DialectMapper {
         if (hibernateDialect instanceof H2Dialect){
             return DialectName.H2;
         }
-        if (hibernateDialect instanceof Oracle8iDialect){
+        if (hibernateDialect instanceof OracleDialect){
             return DialectName.ORACLE;
         }
-        if (hibernateDialect instanceof PostgreSQL81Dialect){
+        if (hibernateDialect instanceof PostgreSQLDialect){
             return DialectName.POSTGRES;
         }
         if (hibernateDialect instanceof MySQLDialect){


### PR DESCRIPTION
Oracle8iDialect and PostgreSQL81Dialect are deprecated in hibernate 6 and the instanceOf does not longer work for this dialects