### PR TITLE
Re-enable db2 support

### DIFF
--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/DialectName.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/DialectName.java
@@ -13,6 +13,8 @@ public enum DialectName {
     POSTGRES,
     ORACLE,
     MYSQL,
+    DB2,
+    DB2400,
 
     /** Microsoft SQL Server*/
     MSSQL;

--- a/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/DialectMapper.java
+++ b/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/DialectMapper.java
@@ -24,6 +24,12 @@ public class DialectMapper {
         if (hibernateDialect instanceof MySQLDialect){
             return DialectName.MYSQL;
         }
+        if (hibernateDialect instanceof DB2Dialect){
+        	return DialectName.DB2;
+        }
+        if (hibernateDialect instanceof DB2400Dialect){
+        	return DialectName.DB2400;
+        }
         throw new JaversException(JaversExceptionCode.UNSUPPORTED_SQL_DIALECT, hibernateDialect.getClass().getSimpleName());
     }
 }


### PR DESCRIPTION
I saw it used to be there, then got remove but I have no idea why.

Can we get DB2 back in?