### PR TITLE
#1206 - Tests to reproduce NPE thrown when Array sample at index 0 is null

### DIFF
--- a/javers-core/src/test/java/org/javers/core/cases/Case1206ArraysNpe.java
+++ b/javers-core/src/test/java/org/javers/core/cases/Case1206ArraysNpe.java
@@ -1,6 +1,9 @@
 package org.javers.core.cases;
 
+import org.javers.core.Changes;
+import org.javers.core.Javers;
 import org.javers.core.JaversBuilder;
+import org.javers.core.diff.Diff;
 import org.javers.core.diff.changetype.container.ArrayChange;
 import org.javers.core.diff.changetype.container.ElementValueChange;
 import org.junit.jupiter.api.Assertions;
@@ -9,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * see https://github.com/javers/javers/issues/1206
+ * https://github.com/javers/javers/issues/1206
  *
  * @author Edgars Garsneks
  */
@@ -27,19 +30,19 @@ public class Case1206ArraysNpe {
 
     @Test
     public void shouldNotThrowNPEWhenSamplingNullRight() {
-        var a = new BeanWithArray("a");
-        var b = new BeanWithArray(new String[]{null});
+        BeanWithArray a = new BeanWithArray("a");
+        BeanWithArray b = new BeanWithArray(new String[]{null});
 
-        var javers = JaversBuilder.javers().build();
+        Javers javers = JaversBuilder.javers().build();
 
         try {
-            var diff = javers.compare(a, b);
-            var changes = diff.getChanges();
+            Diff diff = javers.compare(a, b);
+            Changes changes = diff.getChanges();
 
             Assertions.assertEquals(1, changes.size());
 
-            var change = (ArrayChange) changes.get(0);
-            var elementChange = (ElementValueChange) change.getChanges().get(0);
+            ArrayChange change = (ArrayChange) changes.get(0);
+            ElementValueChange elementChange = (ElementValueChange) change.getChanges().get(0);
 
             Assertions.assertEquals(a.items[0], elementChange.getLeftValue());
             Assertions.assertEquals(b.items[0], elementChange.getRightValue());
@@ -50,19 +53,19 @@ public class Case1206ArraysNpe {
 
     @Test
     public void shouldNotThrowNPEWhenSamplingNullLeft() {
-        var a = new BeanWithArray(new String[]{null});
-        var b = new BeanWithArray("a");
+        BeanWithArray a = new BeanWithArray(new String[]{null});
+        BeanWithArray b = new BeanWithArray("a");
 
-        var javers = JaversBuilder.javers().build();
+        Javers javers = JaversBuilder.javers().build();
 
         try {
-            var diff = javers.compare(a, b);
-            var changes = diff.getChanges();
+            Diff diff = javers.compare(a, b);
+            Changes changes = diff.getChanges();
 
             Assertions.assertEquals(1, changes.size());
 
-            var change = (ArrayChange) changes.get(0);
-            var elementChange = (ElementValueChange) change.getChanges().get(0);
+            ArrayChange change = (ArrayChange) changes.get(0);
+            ElementValueChange elementChange = (ElementValueChange) change.getChanges().get(0);
 
             Assertions.assertEquals(a.items[0], elementChange.getLeftValue());
             Assertions.assertEquals(b.items[0], elementChange.getRightValue());

--- a/javers-core/src/test/java/org/javers/core/cases/Case1206ArraysNpe.java
+++ b/javers-core/src/test/java/org/javers/core/cases/Case1206ArraysNpe.java
@@ -1,0 +1,75 @@
+package org.javers.core.cases;
+
+import org.javers.core.JaversBuilder;
+import org.javers.core.diff.changetype.container.ArrayChange;
+import org.javers.core.diff.changetype.container.ElementValueChange;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * see https://github.com/javers/javers/issues/1206
+ *
+ * @author Edgars Garsneks
+ */
+public class Case1206ArraysNpe {
+
+    static class BeanWithArray {
+
+        private final String[] items;
+
+        public BeanWithArray(String... items) {
+            this.items = items;
+        }
+
+    }
+
+    @Test
+    public void shouldNotThrowNPEWhenSamplingNullRight() {
+        var a = new BeanWithArray("a");
+        var b = new BeanWithArray(new String[]{null});
+
+        var javers = JaversBuilder.javers().build();
+
+        try {
+            var diff = javers.compare(a, b);
+            var changes = diff.getChanges();
+
+            Assertions.assertEquals(1, changes.size());
+
+            var change = (ArrayChange) changes.get(0);
+            var elementChange = (ElementValueChange) change.getChanges().get(0);
+
+            Assertions.assertEquals(a.items[0], elementChange.getLeftValue());
+            Assertions.assertEquals(b.items[0], elementChange.getRightValue());
+        } catch (Exception e) {
+            fail("Should not throw exception when sampling item.", e);
+        }
+    }
+
+    @Test
+    public void shouldNotThrowNPEWhenSamplingNullLeft() {
+        var a = new BeanWithArray(new String[]{null});
+        var b = new BeanWithArray("a");
+
+        var javers = JaversBuilder.javers().build();
+
+        try {
+            var diff = javers.compare(a, b);
+            var changes = diff.getChanges();
+
+            Assertions.assertEquals(1, changes.size());
+
+            var change = (ArrayChange) changes.get(0);
+            var elementChange = (ElementValueChange) change.getChanges().get(0);
+
+            Assertions.assertEquals(a.items[0], elementChange.getLeftValue());
+            Assertions.assertEquals(b.items[0], elementChange.getRightValue());
+        } catch (Exception e) {
+            fail("Should not throw exception when sampling item.", e);
+        }
+    }
+
+
+}


### PR DESCRIPTION
Similarly to #1206 have encountered issue with NPE being thrown on Array diff. This can be reproduced when array hold `null` as its first element. PR holds minimal tests to reproduce.

### Root cause analysis

Null pointer is thrown by code section in [ArrayType](https://github.com/javers/javers/blob/6c847776f8316ad88e1e3f8a6e4dab7efb2dc314/javers-core/src/main/java/org/javers/core/metamodel/type/ArrayType.java#L92C1-L100C1). Sampling only looks at first element of the array, if that element is `null` then `sample.getClass()` will throw NPE.
 
```java
if (doSample) {
    Object sample = mapFunction.apply(Array.get(sourceArray, 0));  <--- Takes first element as null
    if (getItemClass().isAssignableFrom(sample.getClass())) {  <---- throws NPE because getClass() invoked on null
         return Array.newInstance(getItemClass(), len);
     }
 }
 return Array.newInstance(Object.class, len);
```

### Solution proposals
#### Option 1
Instead of taking first element, change it to search for first non-null element. In that case we should consider scenario were all elements are `null`. My assumption would be to use `getItemClass()` as `null` technically can be assigned to it, or play safe and fallback to the `Object.class`.

```java
if (doSample) {
    Optional<Object> nonNullSample = findFirstNonNull(sourceArray, len).map(mapFunction);
    // No non-null values in the array, so we can assume that type is the same
     if (nonNullSample.isEmpty()) {
         return Array.newInstance(getItemClass(), len);
     } else if (getItemClass().isAssignableFrom(nonNullSample.get().getClass())) {
         return Array.newInstance(getItemClass(), len);
    }
 }

return Array.newInstance(Object.class, len);

...

private Optional<Object> findFirstNonNull(Object array, int len) {
    for (int i = 0; i < len; i++) {
         Object val = Array.get(array, i);
         if (val != null) {
             return Optional.of(val);
         }
     }
     return Optional.empty();
}
```

#### Option 2
If this class verification is not crucial to have, as there is fallback to `Object.class`, this section could be removed/or updated that it will attempt to check first item if it is not null, otherwise just fall back. e.g.

```java
if (doSample) {
    Object sample = mapFunction.apply(Array.get(sourceArray, 0));  
    if (sample != null && getItemClass().isAssignableFrom(sample.getClass())) {  <----
         return Array.newInstance(getItemClass(), len);
     }
 }
 return Array.newInstance(Object.class, len);
```

@bartoszwalacik I would like to hear your input on the decision.

