### PR TITLE
#1279 add parameters to compilerArgs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ subprojects {
         options.noTimestamp()
     }
 
+    tasks.withType(JavaCompile).configureEach {
+        options.compilerArgs << '-parameters'
+    }
+
     task example(dependsOn: 'cleanTest') {
         doLast {
             tasks.test.testLogging {


### PR DESCRIPTION
When using javers in a spring-boot service, we get the deprecation warnings mentioned in the issues e.g. for JaversSpringDataAuditableRepositoryAspect