### PR TITLE
add terminalsnapshot configuration and keep terminalsnapshot when it is enabled

### DIFF
--- a/javers-core/src/main/java/org/javers/core/CoreConfiguration.java
+++ b/javers-core/src/main/java/org/javers/core/CoreConfiguration.java
@@ -22,6 +22,7 @@ public class CoreConfiguration {
     private final boolean initialChanges;
 
     private final boolean terminalChanges;
+    private final boolean terminalSnapshot;
 
     private final boolean usePrimitiveDefaults;
 
@@ -29,7 +30,7 @@ public class CoreConfiguration {
 
     private final Supplier<CommitId> customCommitIdGenerator;
 
-    CoreConfiguration(PrettyValuePrinter prettyValuePrinter, MappingStyle mappingStyle, ListCompareAlgorithm listCompareAlgorithm, boolean initialChanges, CommitIdGenerator commitIdGenerator, Supplier<CommitId> customCommitIdGenerator, boolean terminalChanges, boolean prettyPrint,
+    CoreConfiguration(PrettyValuePrinter prettyValuePrinter, MappingStyle mappingStyle, ListCompareAlgorithm listCompareAlgorithm, boolean initialChanges, CommitIdGenerator commitIdGenerator, Supplier<CommitId> customCommitIdGenerator, boolean terminalChanges, boolean terminalSnapshot, boolean prettyPrint,
             boolean usePrimitiveDefaults) {
         this.prettyValuePrinter = prettyValuePrinter;
         this.mappingStyle = mappingStyle;
@@ -38,6 +39,7 @@ public class CoreConfiguration {
         this.commitIdGenerator = commitIdGenerator;
         this.customCommitIdGenerator = customCommitIdGenerator;
         this.terminalChanges = terminalChanges;
+        this.terminalSnapshot = terminalSnapshot;
         this.prettyPrint = prettyPrint;
         this.usePrimitiveDefaults = usePrimitiveDefaults;
     }
@@ -65,6 +67,8 @@ public class CoreConfiguration {
     public boolean isTerminalChanges() {
         return terminalChanges;
     }
+
+    public boolean isTerminalSnapshot() { return terminalSnapshot; }
 
     public CommitIdGenerator getCommitIdGenerator() {
         return commitIdGenerator;

--- a/javers-core/src/main/java/org/javers/core/CoreConfigurationBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/CoreConfigurationBuilder.java
@@ -20,6 +20,8 @@ class CoreConfigurationBuilder {
 
     private boolean terminalChanges = true;
 
+    private boolean terminalSnapshot = false;
+
     private boolean usePrimitiveDefaults = true;
 
     private CommitIdGenerator commitIdGenerator = CommitIdGenerator.SYNCHRONIZED_SEQUENCE;
@@ -42,6 +44,7 @@ class CoreConfigurationBuilder {
                 commitIdGenerator,
                 customCommitIdGenerator,
                 terminalChanges,
+                terminalSnapshot,
                 prettyPrint,
                 usePrimitiveDefaults
         );
@@ -80,6 +83,11 @@ class CoreConfigurationBuilder {
 
     CoreConfigurationBuilder withTerminalChanges(boolean terminalChanges) {
         this.terminalChanges = terminalChanges;
+        return this;
+    }
+
+    CoreConfigurationBuilder withTerminalSnapshot(boolean terminalSnapshot) {
+        this.terminalSnapshot = terminalSnapshot;
         return this;
     }
 

--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -785,6 +785,30 @@ public class JaversBuilder extends AbstractContainerBuilder {
         return this;
     }
 
+    /**
+     * The <b>Terminal Snapshot</b> switch, disabled by default since Javers 7.3.9.
+     * <br/><br/>
+     *
+     * When the switch is enabled, Terminal Snapshot will not have empty state.
+     * It is useful to get deleted records with actual state instead of empty state.
+     * It will not change the behaviour of Terminal changes calculation.
+     * In Javers Spring Boot starter you can enable Terminal Snapshot in `application.yml`:
+     *
+     * <pre>
+     * javers:
+     *   terminalSnapshot: true
+     * </pre>
+     *
+     * @since 7.3.9
+     * @see ObjectRemoved
+     * @see JaversBuilder#withUsePrimitiveDefaults(boolean)
+     * @see JaversBuilder#withInitialChanges(boolean) (boolean)
+     */
+    public JaversBuilder withTerminalSnapshot(boolean terminalSnapshot){
+        configurationBuilder().withTerminalSnapshot(terminalSnapshot);
+        return this;
+    }
+
     public JaversBuilder withObjectAccessHook(ObjectAccessHook objectAccessHook) {
         removeComponent(ObjectAccessHook.class);
         bindComponent(ObjectAccessHook.class, objectAccessHook);
@@ -883,6 +907,9 @@ public class JaversBuilder extends AbstractContainerBuilder {
         }
         if (javersProperties.isTerminalChanges() != null) {
             withTerminalChanges(javersProperties.isTerminalChanges());
+        }
+        if (javersProperties.isTerminalSnapshot() != null) {
+            withTerminalSnapshot(javersProperties.isTerminalSnapshot());
         }
         if (javersProperties.isUsePrimitiveDefaults() != null) {
             withUsePrimitiveDefaults(javersProperties.isUsePrimitiveDefaults());

--- a/javers-core/src/main/java/org/javers/core/JaversCoreProperties.java
+++ b/javers-core/src/main/java/org/javers/core/JaversCoreProperties.java
@@ -15,6 +15,7 @@ public abstract class JaversCoreProperties {
     private String mappingStyle;
     private Boolean initialChanges;
     private Boolean terminalChanges;
+    private Boolean terminalSnapshot;
     private Boolean prettyPrint;
     private Boolean typeSafeValues;
     private String packagesToScan = "";
@@ -55,6 +56,10 @@ public abstract class JaversCoreProperties {
 
     public Boolean isTerminalChanges() {
         return terminalChanges;
+    }
+
+    public Boolean isTerminalSnapshot() {
+        return terminalSnapshot;
     }
 
     public Boolean isPrettyPrint() {

--- a/javers-core/src/main/java/org/javers/core/snapshot/SnapshotDiffer.java
+++ b/javers-core/src/main/java/org/javers/core/snapshot/SnapshotDiffer.java
@@ -9,12 +9,15 @@ import org.javers.core.diff.Diff;
 import org.javers.core.diff.DiffFactory;
 import org.javers.core.diff.changetype.ObjectRemoved;
 import org.javers.core.metamodel.object.CdoSnapshot;
+import org.javers.core.metamodel.object.CdoSnapshotBuilder;
 import org.javers.repository.api.SnapshotIdentifier;
 
 import java.util.*;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static org.javers.core.metamodel.object.CdoSnapshotBuilder.cdoSnapshot;
+import static org.javers.core.metamodel.object.SnapshotType.TERMINAL;
 
 public class SnapshotDiffer {
 
@@ -59,7 +62,14 @@ public class SnapshotDiffer {
     private void addTerminalChanges(List<Change> changes, CdoSnapshot terminalSnapshot, CdoSnapshot previousSnapshot) {
         changes.add(new ObjectRemoved(terminalSnapshot.getGlobalId(), empty(), of(terminalSnapshot.getCommitMetadata())));
         if (previousSnapshot != null && javersCoreConfiguration.isTerminalChanges()) {
-            Diff terminalDiff = diffFactory.create(snapshotGraph(previousSnapshot), snapshotGraph(terminalSnapshot), commitMetadata(terminalSnapshot));
+            CdoSnapshot terminalSnapshotWithEmptyState = cdoSnapshot()
+                    .withGlobalId(terminalSnapshot.getGlobalId())
+                    .withManagedType(terminalSnapshot.getManagedType())
+                    .withCommitMetadata(terminalSnapshot.getCommitMetadata())
+                    .withType(terminalSnapshot.getType())
+                    .withVersion(terminalSnapshot.getVersion())
+                    .build();
+            Diff terminalDiff = diffFactory.create(snapshotGraph(previousSnapshot), snapshotGraph(terminalSnapshotWithEmptyState), commitMetadata(terminalSnapshot));
             changes.addAll(terminalDiff.getChanges());
         }
     }

--- a/javers-core/src/test/groovy/org/javers/core/commit/CommitAssert.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/commit/CommitAssert.groovy
@@ -89,4 +89,9 @@ class CommitAssert {
         snapshotsAssert.hasTerminalSnapshot(expectedSnapshotId)
         this
     }
+
+    CommitAssert shouldHaveTerminalSnapshot(def expectedSnapshotId){
+        snapshotsAssert.shouldHaveTerminalSnapshot(expectedSnapshotId)
+        this
+    }
 }

--- a/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotsAssert.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotsAssert.groovy
@@ -45,6 +45,14 @@ class SnapshotsAssert {
         this
     }
 
+    SnapshotsAssert shouldHaveTerminalSnapshot(def expectedId){
+        def found = actual.find { it -> it.globalId == expectedId}
+
+        assert found.size() > 0 //terminal snapshot should not be empty when terminalSnapshot configuration is enabled
+        assert found.terminal
+        this
+    }
+
     private SnapshotsAssert assertState(CdoSnapshot found, Map<String, Object> expectedState) {
         assert found != null
         assert expectedState.size() == found.size()


### PR DESCRIPTION
refer to https://stackoverflow.com/questions/38696077/how-to-retrieve-deleted-record.

then with code snippet:
javersBuilder.withTerminalSnapshot(true);

queryBuilder.withSnapshotType(SnapshotType.TERMINAL);
javers.findShadows(queryBuilder.build());

to easily get the deleted records.

