### PR TITLE
ReflectionUtil.calculateHierarchyDistance should return superinterfaces

### DIFF
--- a/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
+++ b/javers-core/src/main/java/org/javers/common/reflection/ReflectionUtil.java
@@ -239,10 +239,17 @@ public class ReflectionUtil {
                 parents.add(current);
             }
 
-            for (Class i : current.getInterfaces()) {
-                if (!interfaces.contains(i)) {
-                    interfaces.add(i);
+            Class<?>[] currentInterfaces = current.getInterfaces();
+            while (currentInterfaces.length != 0) {
+                for (final Class<?> i : currentInterfaces) {
+                    if (!interfaces.contains(i)) {
+                        interfaces.add(i);
+                    }
                 }
+
+                currentInterfaces = Arrays.stream(currentInterfaces)
+                        .flatMap(currentInterface -> Arrays.stream(currentInterface.getInterfaces()))
+                        .toArray(Class<?>[]::new);
             }
 
             current = current.getSuperclass();

--- a/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/common/reflection/ReflectionUtilTest.groovy
@@ -66,7 +66,7 @@ class ReflectionUtilTest extends Specification {
 
     def "should calculate hierarchy distance as follows (parents first, interfaces last)"() {
         expect:
-        ReflectionUtil.calculateHierarchyDistance(HashMap) == [AbstractMap, Map, Cloneable, Serializable]
+        ReflectionUtil.calculateHierarchyDistance(TreeMap) == [AbstractMap, NavigableMap, Cloneable, Serializable, SortedMap, Map]
     }
 
     def "should get all methods from a given class without inheritance duplicates"(){

--- a/javers-core/src/test/groovy/org/javers/core/cases/Java21SortedMapShouldBeStillMappedToJaversMapType.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/cases/Java21SortedMapShouldBeStillMappedToJaversMapType.groovy
@@ -1,0 +1,26 @@
+package org.javers.core.cases
+
+
+import org.javers.core.JaversBuilder
+import org.javers.core.metamodel.type.MapType
+import spock.lang.Specification
+
+/**
+ * Related also to issue https://github.com/javers/javers/issues/916 which suggest the in fact:
+ * {@link org.javers.common.reflection.ReflectionUtil#calculateHierarchyDistance} should return not only direct
+ * interfaces but superinterfaces as well.
+ * @author simone giusso
+ */
+class Java21SortedMapShouldBeStillMappedToJaversMapType extends Specification{
+
+    def "should map java 21 SortedMap to Javers MapType instead of ValueObjectType"() {
+        given:
+        final def javers = JaversBuilder.javers().build();
+
+        when:
+        final def jType = javers.getTypeMapping(SortedMap)
+
+        then:
+        jType instanceof MapType
+    }
+}


### PR DESCRIPTION
This is related to this [issue](https://github.com/javers/javers/issues/916). Actually we noticed this problem when we upgraded our project from Java 17 to Java 21. 

In fact the call to `Javers#compare` on objects which have a property of Type `SortedMap` (assigned to `TreeMap` concrete class) fails in Java 21 with an error similar to:

> JaversException MANAGED_CLASS_MAPPING_ERROR: given javaClass ‘class java.util.TreeMap’ is mapped to MapType, expected ManagedType

While in Java 17, it works. 

The reason is that the mapping between `SortedMap` and JaversType changes when using the two Java versions:

- in Java 17 `SortedMap` is mapped to `MapType` (not a `ManagedType`) ✅
- in Java 21 `SortedMap` is mapped to `ValueObjectType` (subclass of `ManagedType`) ❌

**This is the issue `SortedMap` is not correctly mapped when using Java 21.** 

Full stack error:
> Caused by: org.javers.common.exception.JaversException: MANAGED_CLASS_MAPPING_ERROR: given javaClass ‘class java.util.TreeMap’ is mapped to MapType, expected ManagedType
> 	at org.javers.core.metamodel.type.TypeMapper.getJaversManagedType(TypeMapper.java:178)
> 	at org.javers.core.metamodel.type.TypeMapper.getJaversManagedType(TypeMapper.java:161)
> 	at org.javers.core.metamodel.object.GlobalIdFactory.createId(GlobalIdFactory.java:45)
> 	at org.javers.core.graph.LiveCdoFactory.create(LiveCdoFactory.java:37)
> 	at org.javers.core.graph.EdgeBuilder.buildSingleEdge(EdgeBuilder.java:33)
> 	at org.javers.core.graph.ObjectGraphBuilder.buildSingleEdges(ObjectGraphBuilder.java:107)
> 	at org.javers.core.graph.ObjectGraphBuilder.buildEdges(ObjectGraphBuilder.java:97)
> 	at org.javers.core.graph.ObjectGraphBuilder.buildGraphFromCdo(ObjectGraphBuilder.java:65)
> 	at org.javers.core.graph.ObjectGraphBuilder.buildGraph(ObjectGraphBuilder.java:54)
> 	at org.javers.core.graph.LiveGraphFactory.createLiveGraph(LiveGraphFactory.java:38)
> 	at org.javers.core.diff.DiffFactory.buildGraph(DiffFactory.java:102)
> 	at org.javers.core.diff.DiffFactory.compare(DiffFactory.java:55)
> 	at org.javers.core.JaversCore.compare(JaversCore.java:176)
 
P.S. The message exception, as it is written,  is due to the fact that, at first the `SortedMap` property is considered as `ManagedType` as explained above. Therefore the call to `ObjectGraphBuilder.buildSingleEdges(ObjectGraphBuilder.java:107)` with this property. However since the instance is of `TreeMap`, when retrieving the `JaversManagedType` at `TypeMapper.getJaversManagedType(TypeMapper.java:170`) ,right before the exception, it returns `MapType`. 

It may be related to the following issue as well:

https://github.com/javers/javers/issues/1090