### PR TITLE
Resolving bug #1415 to serialized Double.NaN 

### DIFF
--- a/javers-core/src/main/java/org/javers/core/json/JsonConverterBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/json/JsonConverterBuilder.java
@@ -24,6 +24,7 @@ public class JsonConverterBuilder {
 
     public JsonConverterBuilder() {
         this.gsonBuilder = new GsonBuilder();
+        this.gsonBuilder.serializeSpecialFloatingPointValues();
         this.gsonBuilder.setExclusionStrategies(new SkipFieldExclusionStrategy());
         this.gsonBuilder.setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE);
         registerBuiltInAdapters(Java8TypeAdapters.adapters());

--- a/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/JaversMongoStarterNullDoubleTest.groovy
+++ b/javers-spring-boot-starter-mongo/src/test/groovy/org/javers/spring/boot/mongo/JaversMongoStarterNullDoubleTest.groovy
@@ -1,0 +1,44 @@
+package org.javers.spring.boot.mongo
+
+import com.mongodb.client.MongoClient
+import org.javers.core.CommitIdGenerator
+import org.javers.core.Javers
+import org.javers.core.MappingStyle
+import org.javers.core.diff.ListCompareAlgorithm
+import org.javers.repository.jql.QueryBuilder
+import org.springframework.beans.factory.annotation.Autowired
+
+/**
+ * @author bbrakefieldmn
+ */
+class JaversMongoStarterNullDoubleTest extends BaseSpecification{
+    static String DB_NAME = 'spring-mongo-default'
+
+    @Autowired Javers javers
+
+    @Autowired
+    private MongoClient mongoClient;
+
+    @Autowired
+    JaversMongoProperties javersProperties
+
+    def setup () {
+         mongoClient.getDatabase(DB_NAME).getCollection("jv_snapshots").drop()
+    }
+
+
+    def "should persist entity with Double.NaN value to Mongo"(){
+      when:
+      def dummyEntity = new DummyEntityWithDouble(UUID.randomUUID().hashCode(), Double.NaN)
+      javers.commit("a", dummyEntity)
+      def snapshots = javers.findSnapshots(QueryBuilder.byInstance(dummyEntity).build())
+
+      then:
+      javers.repository.delegate.mongoSchemaManager.mongo.name == "spring-mongo-default"
+      snapshots.size() == 1
+
+      mongoClient.getDatabase(DB_NAME).getCollection("jv_snapshots").countDocuments() == 1
+    }
+
+
+}

--- a/javers-spring-boot-starter-mongo/src/test/java/org/javers/spring/boot/mongo/DummyEntityWithDouble.java
+++ b/javers-spring-boot-starter-mongo/src/test/java/org/javers/spring/boot/mongo/DummyEntityWithDouble.java
@@ -1,0 +1,25 @@
+package org.javers.spring.boot.mongo;
+
+import org.javers.core.metamodel.annotation.Id;
+
+/**
+ * @author bbrakefieldmn
+ */
+public class DummyEntityWithDouble {
+
+    @Id
+    private final int id;
+    private final double doubleValue;
+
+    public DummyEntityWithDouble(int id, double doubleValue) {
+        this.id = id;
+        this.doubleValue = doubleValue;
+    }
+
+    @Id
+    public int getId() {
+        return id;
+    }
+
+    public double getDoubleValue() {return doubleValue;}
+}


### PR DESCRIPTION
This PR resolves the issue found here: https://github.com/javers/javers/issues/1415

The previously failing test case now correctly persists the object containing Double.NaN. 