### PR TITLE
#1440 custom sequence table names new configuration to be added to do…

### DIFF
--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/SqlRepositoryBuilder.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/SqlRepositoryBuilder.java
@@ -33,6 +33,11 @@ public class SqlRepositoryBuilder extends AbstractContainerBuilder {
     private String snapshotTableName;
     private String commitPropertyTableName;
 
+    private String globalIdSequenceName;
+    private String commitSequenceName;
+    private String snapshotSequenceName;
+
+
     public SqlRepositoryBuilder() {
     }
 
@@ -111,6 +116,28 @@ public class SqlRepositoryBuilder extends AbstractContainerBuilder {
         return this;
     }
 
+    public SqlRepositoryBuilder withGlobalIdSequenceName(String globalIdSequenceName) {
+        if(isNonEmpty(globalIdSequenceName)) {
+            this.globalIdSequenceName = globalIdSequenceName;
+        }
+        return this;
+    }
+
+    public SqlRepositoryBuilder withCommitSequenceName(String commitSequenceName) {
+        if(isNonEmpty(commitSequenceName)) {
+            this.commitSequenceName = commitSequenceName;
+        }
+        return this;
+    }
+
+    public SqlRepositoryBuilder withSnapshotSequenceName(String snapshotSequenceName) {
+        if(isNonEmpty(snapshotSequenceName)) {
+            this.snapshotSequenceName = snapshotSequenceName;
+        }
+        return this;
+    }
+
+
     public JaversSqlRepository build() {
         logger.info("starting SqlRepository...");
         logger.info("  dialect:                  {}", dialectName);
@@ -120,7 +147,8 @@ public class SqlRepositoryBuilder extends AbstractContainerBuilder {
 
         SqlRepositoryConfiguration config =
                 new SqlRepositoryConfiguration(globalIdCacheDisabled, schemaName, schemaManagementEnabled,
-                        globalIdTableName, commitTableName, snapshotTableName, commitPropertyTableName);
+                        globalIdTableName, commitTableName, snapshotTableName, commitPropertyTableName,
+                        globalIdSequenceName, commitSequenceName, snapshotSequenceName);
         addComponent(config);
 
         PolyJDBC polyJDBC = PolyJDBCBuilder.polyJDBC(dialectName.getPolyDialect(), config.getSchemaName())

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/SqlRepositoryConfiguration.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/SqlRepositoryConfiguration.java
@@ -17,10 +17,15 @@ public class SqlRepositoryConfiguration {
     private final String snapshotTableName;
     private final String commitPropertyTableName;
 
+    private final String globalIdSequenceName;
+    private final String commitSequenceName;
+    private final String snapshotSequenceName;
+
     SqlRepositoryConfiguration(boolean globalIdCacheDisabled, String schemaName,
-                                      boolean schemaManagementEnabled, String globalIdTableName,
-                                      String commitTableName,
-                                      String snapshotTableName, String commitPropertyTableName) {
+                               boolean schemaManagementEnabled, String globalIdTableName,
+                               String commitTableName, String snapshotTableName, String commitPropertyTableName,
+                               String globalIdSequenceName, String commitSequenceName, String snapshotSequenceName
+                               ) {
         Validate.argumentCheck(schemaName == null || !schemaName.isEmpty(),"schemaName should be null or non-empty");
 
         this.globalIdCacheDisabled = globalIdCacheDisabled;
@@ -30,6 +35,9 @@ public class SqlRepositoryConfiguration {
         this.commitTableName = commitTableName;
         this.snapshotTableName = snapshotTableName;
         this.commitPropertyTableName = commitPropertyTableName;
+        this.globalIdSequenceName = globalIdSequenceName;
+        this.commitSequenceName = commitSequenceName;
+        this.snapshotSequenceName = snapshotSequenceName;
     }
 
     public boolean isGlobalIdCacheDisabled() {
@@ -66,4 +74,17 @@ public class SqlRepositoryConfiguration {
     public Optional<String> getCommitPropertyTableName() {
         return Optional.ofNullable(commitPropertyTableName);
     }
+
+    public Optional<String> getGlobalIdSequenceName() {
+        return Optional.ofNullable(globalIdSequenceName);
+    }
+
+    public Optional<String> getCommitSequenceName() {
+        return Optional.ofNullable(commitSequenceName);
+    }
+
+    public Optional<String> getSnapshotSequenceName() {
+        return Optional.ofNullable(snapshotSequenceName);
+    }
+
 }

--- a/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/TableNameProvider.java
+++ b/javers-persistence-sql/src/main/java/org/javers/repository/sql/schema/TableNameProvider.java
@@ -47,15 +47,15 @@ public class TableNameProvider {
     }
 
     public DBObjectName getSnapshotTablePkSeqName() {
-        return fullDbName(SNAPSHOT_TABLE_PK_SEQ);
+        return fullDbName(configuration.getSnapshotSequenceName().orElse(SNAPSHOT_TABLE_PK_SEQ));
     }
 
     public DBObjectName getGlobalIdPkSeqName() {
-        return fullDbName(GLOBAL_ID_PK_SEQ);
+        return fullDbName(configuration.getGlobalIdSequenceName().orElse(GLOBAL_ID_PK_SEQ));
     }
 
     public DBObjectName getCommitPkSeqName() {
-        return fullDbName(COMMIT_PK_SEQ);
+        return fullDbName(configuration.getCommitSequenceName().orElse(COMMIT_PK_SEQ));
     }
 
     /**

--- a/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversSqlAutoConfiguration.java
+++ b/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversSqlAutoConfiguration.java
@@ -84,6 +84,9 @@ public class JaversSqlAutoConfiguration {
                 .withCommitTableName(javersSqlProperties.getSqlCommitTableName())
                 .withSnapshotTableName(javersSqlProperties.getSqlSnapshotTableName())
                 .withCommitPropertyTableName(javersSqlProperties.getSqlCommitPropertyTableName())
+                .withGlobalIdSequenceName(javersSqlProperties.getSqlGlobalIdSequenceName())
+                .withCommitSequenceName(javersSqlProperties.getSqlCommitSequenceName())
+                .withSnapshotSequenceName(javersSqlProperties.getSqlSnapshotSequenceName())
                 .build();
     }
 

--- a/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversSqlProperties.java
+++ b/javers-spring-boot-starter-sql/src/main/java/org/javers/spring/boot/sql/JaversSqlProperties.java
@@ -15,6 +15,10 @@ public class JaversSqlProperties extends JaversSpringProperties {
     private String sqlCommitTableName;
     private String sqlSnapshotTableName;
     private String sqlCommitPropertyTableName;
+    private String sqlGlobalIdSequenceName;
+    private String sqlCommitSequenceName;
+    private String sqlSnapshotSequenceName;
+
 
     public boolean isSqlSchemaManagementEnabled() {
         return sqlSchemaManagementEnabled;
@@ -74,5 +78,29 @@ public class JaversSqlProperties extends JaversSpringProperties {
 
     public void setSqlCommitPropertyTableName(String sqlCommitPropertyTableName) {
         this.sqlCommitPropertyTableName = sqlCommitPropertyTableName;
+    }
+
+    public String getSqlGlobalIdSequenceName() {
+        return sqlGlobalIdSequenceName;
+    }
+
+    public void setSqlGlobalIdSequenceName(String sqlGlobalIdSequenceName) {
+        this.sqlGlobalIdSequenceName = sqlGlobalIdSequenceName;
+    }
+
+    public String getSqlCommitSequenceName() {
+        return sqlCommitSequenceName;
+    }
+
+    public void setSqlCommitSequenceName(String sqlCommitSequenceName) {
+        this.sqlCommitSequenceName = sqlCommitSequenceName;
+    }
+
+    public String getSqlSnapshotSequenceName() {
+        return sqlSnapshotSequenceName;
+    }
+
+    public void setSqlSnapshotSequenceName(String sqlSnapshotSequenceName) {
+        this.sqlSnapshotSequenceName = sqlSnapshotSequenceName;
     }
 }

--- a/javers-spring-boot-starter-sql/src/test/groovy/org/javers/spring/sql/JaversSqlAutoConfigurationDefaultPropsTest.groovy
+++ b/javers-spring-boot-starter-sql/src/test/groovy/org/javers/spring/sql/JaversSqlAutoConfigurationDefaultPropsTest.groovy
@@ -57,6 +57,9 @@ class JaversSqlAutoConfigurationDefaultPropsTest extends Specification {
         javersProperties.sqlCommitTableName == null
         javersProperties.sqlSnapshotTableName == null
         javersProperties.sqlCommitPropertyTableName == null
+        javersProperties.sqlGlobalIdSequenceName == null
+        javersProperties.sqlCommitSequenceName == null
+        javersProperties.sqlSnapshotSequenceName == null
     }
 
     def "shouldHaveSpringSecurityAuthorProviderWhenSpringSecurityOnClasspath"() {

--- a/javers-spring-boot-starter-sql/src/test/groovy/org/javers/spring/sql/JaversSqlAutoConfigurationTest.groovy
+++ b/javers-spring-boot-starter-sql/src/test/groovy/org/javers/spring/sql/JaversSqlAutoConfigurationTest.groovy
@@ -60,6 +60,9 @@ class JaversSqlAutoConfigurationTest extends Specification {
         javersProperties.sqlCommitTableName == "cust_jv_commit"
         javersProperties.sqlSnapshotTableName == "cust_jv_snapshot"
         javersProperties.sqlCommitPropertyTableName == "cust_jv_commit_property"
+        javersProperties.sqlGlobalIdSequenceName == "cust_jv_global_id_pk_seq"
+        javersProperties.sqlCommitSequenceName == "cust_jv_commit_pk_seq"
+        javersProperties.sqlSnapshotSequenceName == "cust_jv_snapshot_pk_seq"
     }
 
     def "shouldHaveSpringSecurityAuthorProviderWhenSpringSecurityOnClasspath" () {

--- a/javers-spring-boot-starter-sql/src/test/resources/application-test.yml
+++ b/javers-spring-boot-starter-sql/src/test/resources/application-test.yml
@@ -23,4 +23,7 @@ javers:
   sqlCommitTableName: 'cust_jv_commit'
   sqlSnapshotTableName: 'cust_jv_snapshot'
   sqlCommitPropertyTableName: 'cust_jv_commit_property'
+  sqlGlobalIdSequenceName: 'cust_jv_global_id_pk_seq'
+  sqlCommitSequenceName: 'cust_jv_commit_pk_seq'
+  sqlSnapshotSequenceName: 'cust_jv_snapshot_pk_seq'
   usePrimitiveDefaults: false


### PR DESCRIPTION
#1440 custom sequence table names new configuration to be added to documentation:

  javers.sqlGlobalIdSequenceName: 'cust_jv_global_id_pk_seq'
  javers.sqlCommitSequenceName: 'cust_jv_commit_pk_seq'
  javers.sqlSnapshotSequenceName: 'cust_jv_snapshot_pk_seq'