### PR TITLE
type parameter resolution for complex hierarchies

### DIFF
--- a/javers-core/src/main/java/org/javers/core/metamodel/type/ArrayType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/ArrayType.java
@@ -118,6 +118,6 @@ public class ArrayType extends ContainerType {
 
     @Override
     public Class<?> getEnumerableInterface() {
-        throw new JaversException(JaversExceptionCode.NOT_IMPLEMENTED);
+        throw new JaversException(JaversExceptionCode.NOT_IMPLEMENTED, "Array types do not have an interface");
     }
 }

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/EnumerableType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/EnumerableType.java
@@ -1,12 +1,15 @@
 package org.javers.core.metamodel.type;
 
 import org.javers.common.collections.EnumerableFunction;
-
+import java.lang.reflect.ParameterizedType;
 import java.util.*;
+import org.javers.common.exception.JaversException;
+import org.javers.common.reflection.ReflectionUtil;
 import org.javers.common.validation.Validate;
 import org.javers.core.metamodel.object.OwnerContext;
 import java.lang.reflect.Type;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,10 +21,75 @@ import static java.util.Collections.unmodifiableList;
  */
 public abstract class EnumerableType extends ClassType {
     private final TypeMapperLazy typeMapperLazy;
+    private final List<Type> concreteTypeArguments;
 
     EnumerableType(Type baseJavaType, int expectedArgs, TypeMapperLazy typeMapperLazy) {
         super(baseJavaType, Optional.empty(), expectedArgs);
         this.typeMapperLazy = typeMapperLazy;
+        this.concreteTypeArguments = buildEnumerableConcreteTypeArguments(expectedArgs).map(Collections::unmodifiableList).orElse(null);
+    }
+
+    private Optional<List<Type>> buildEnumerableConcreteTypeArguments(int expectedArgs) {
+        if (isNonDefaultEnumerableTypeParameters(super.getConcreteClassTypeArguments(), expectedArgs))
+            return Optional.empty(); // baseJavaType has the needed type parameters, delegate logic to base class
+
+        final Class<?> enumerableClass = ((Supplier<Class<?>>) () -> {
+            try {
+                return getEnumerableInterface();
+            } catch (JaversException ex) {
+                return null;
+            }
+        }).get();
+        if (enumerableClass == null)
+            return Optional.empty(); // Some enumerable types (e.g. Array) don't have a common interface
+
+        final Class<?> baseJavaClass = getBaseJavaClass();
+        if (baseJavaClass == enumerableClass)
+            return Optional.empty(); // No need to traverse inheritance tree, delegate logic to base class
+
+        for (Class<?> current = baseJavaClass; current != null && enumerableClass.isAssignableFrom(current); current = current.getSuperclass()) {
+            final Type superClass = current.getGenericSuperclass();
+            if (superClass instanceof ParameterizedType) {
+                final Type rawType = ((ParameterizedType) superClass).getRawType();
+                if (rawType instanceof Class && enumerableClass.isAssignableFrom((Class<?>) rawType)) {
+                    final List<Type> typeParameters = buildListOfConcreteTypeArguments(superClass, expectedArgs);
+                    if (isNonDefaultEnumerableTypeParameters(typeParameters, expectedArgs))
+                        return Optional.of(typeParameters);
+                }
+            }
+
+            final ArrayList<Type> interfaces = new ArrayList<>(Arrays.asList(current.getGenericInterfaces()));
+            for (int i = 0; i < interfaces.size(); ++i) {
+                final Type curInterface = interfaces.get(i);
+
+                final List<Type> superInterfaces = Arrays.asList(ReflectionUtil.extractClass(curInterface).getGenericInterfaces());
+                interfaces.addAll(superInterfaces);
+
+                if (!(curInterface instanceof ParameterizedType))
+                    continue;
+
+                final Type rawType = ((ParameterizedType) curInterface).getRawType();
+                if (!(rawType instanceof Class && enumerableClass.isAssignableFrom((Class<?>) rawType)))
+                    continue;
+
+                final List<Type> typeParameters = buildListOfConcreteTypeArguments(curInterface, expectedArgs);
+                if (isNonDefaultEnumerableTypeParameters(typeParameters, expectedArgs))
+                    return Optional.of(typeParameters);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    static private boolean isNonDefaultEnumerableTypeParameters(List<Type> typeParameters, int expectedArgs) {
+        return typeParameters != null && typeParameters.size() == expectedArgs && typeParameters.stream().anyMatch(it -> it != DEFAULT_TYPE_PARAMETER);
+    }
+
+    @Override
+    public List<Type> getConcreteClassTypeArguments() {
+        if (concreteTypeArguments == null)
+            return super.getConcreteClassTypeArguments();
+        return concreteTypeArguments;
     }
 
     @Override

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/JaversType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/JaversType.java
@@ -132,7 +132,7 @@ public abstract class JaversType {
                 .addField("typeName", getName());
     }
 
-    private static List<Type> buildListOfConcreteTypeArguments(Type baseJavaType, int expectedSize) {
+    protected static List<Type> buildListOfConcreteTypeArguments(Type baseJavaType, int expectedSize) {
 
         List<Type> allTypeArguments = ReflectionUtil.getAllTypeArguments(baseJavaType);
 

--- a/javers-core/src/test/groovy/org/javers/core/cases/CollectionTypeParameterResolutionTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/cases/CollectionTypeParameterResolutionTest.groovy
@@ -1,0 +1,265 @@
+package org.javers.core.cases
+
+import org.javers.core.JaversBuilder
+import org.javers.core.metamodel.type.CollectionType
+import spock.lang.Specification
+
+/**
+ * https://github.com/javers/javers/issues/1450
+ *
+ * These tests use {@link java.util.Set}, but they should apply to any types that
+ * are handled by {@link org.javers.core.metamodel.type.CollectionType},
+ * since they all have a single type parameter.
+ *
+ * @author Yat Ho
+ */
+class CollectionTypeParameterResolutionTest extends Specification {
+    class ExtendsSetSubtype extends HashSet<String> {}
+
+    def "should recognise value type from Set subtype"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<CollectionType> getTypeMapping(ExtendsSetSubtype)
+        def expectedJType = javers.<CollectionType> getTypeMapping(ExtendsSetSubtype.getGenericSuperclass())
+
+        then:
+        jType.getItemJavaType() == expectedJType.getItemJavaType()
+    }
+
+    class ImplementsSet implements Set<String> {
+        @Override
+        int size() {
+            return 0
+        }
+
+        @Override
+        boolean isEmpty() {
+            return false
+        }
+
+        @Override
+        boolean contains(Object o) {
+            return false
+        }
+
+        @Override
+        Iterator<String> iterator() {
+            return null
+        }
+
+        @Override
+        Object[] toArray() {
+            return null
+        }
+
+        @Override
+        <T> T[] toArray(T[] a) {
+            return null
+        }
+
+        @Override
+        boolean add(String s) {
+            return false
+        }
+
+        @Override
+        boolean remove(Object o) {
+            return false
+        }
+
+        @Override
+        boolean containsAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        boolean addAll(Collection<? extends String> c) {
+            return false
+        }
+
+        @Override
+        boolean retainAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        boolean removeAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        void clear() {}
+    }
+    def "should recognise value type from Set interface"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<CollectionType> getTypeMapping(ImplementsSet)
+        def expectedJType = javers.<CollectionType> getTypeMapping(ImplementsSet.getGenericInterfaces()[0])
+
+        then:
+        jType.getItemJavaType() == expectedJType.getItemJavaType()
+    }
+
+    interface ExtendsSet extends Set<String> {}
+    class ImplementsExtendsSet implements ExtendsSet {
+        @Override
+        int size() {
+            return 0
+        }
+
+        @Override
+        boolean isEmpty() {
+            return false
+        }
+
+        @Override
+        boolean contains(Object o) {
+            return false
+        }
+
+        @Override
+        Iterator<String> iterator() {
+            return null
+        }
+
+        @Override
+        Object[] toArray() {
+            return null
+        }
+
+        @Override
+        <T> T[] toArray(T[] a) {
+            return null
+        }
+
+        @Override
+        boolean add(String s) {
+            return false
+        }
+
+        @Override
+        boolean remove(Object o) {
+            return false
+        }
+
+        @Override
+        boolean containsAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        boolean addAll(Collection<? extends String> c) {
+            return false
+        }
+
+        @Override
+        boolean retainAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        boolean removeAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        void clear() {}
+    }
+
+    def "should recognise value type from Set subinterface"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<CollectionType> getTypeMapping(ImplementsExtendsSet)
+        def expectedJType = javers.<CollectionType> getTypeMapping(ImplementsExtendsSet.getInterfaces()[0].getGenericInterfaces()[0])
+
+        then:
+        jType.getItemJavaType() == expectedJType.getItemJavaType()
+    }
+
+    class EmptyClass {}
+
+    class ExtendsEmptyClass extends EmptyClass {}
+
+    class ExtendsImplementsSetInMiddle extends ExtendsEmptyClass implements Set<String> {
+        @Override
+        int size() {
+            return 0
+        }
+
+        @Override
+        boolean isEmpty() {
+            return false
+        }
+
+        @Override
+        boolean contains(Object o) {
+            return false
+        }
+
+        @Override
+        Iterator<String> iterator() {
+            return null
+        }
+
+        @Override
+        Object[] toArray() {
+            return null
+        }
+
+        @Override
+        <T> T[] toArray(T[] a) {
+            return null
+        }
+
+        @Override
+        boolean add(String s) {
+            return false
+        }
+
+        @Override
+        boolean remove(Object o) {
+            return false
+        }
+
+        @Override
+        boolean containsAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        boolean addAll(Collection<? extends String> c) {
+            return false
+        }
+
+        @Override
+        boolean retainAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        boolean removeAll(Collection<?> c) {
+            return false
+        }
+
+        @Override
+        void clear() {}
+    }
+
+    def "should recognise value type when Set is not the superest superinterface"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<CollectionType> getTypeMapping(ExtendsImplementsSetInMiddle)
+        def expectedJType = javers.<CollectionType> getTypeMapping(ExtendsImplementsSetInMiddle.getGenericInterfaces()[0])
+
+        then:
+        jType.getItemJavaType() == expectedJType.getItemJavaType()
+    }
+}

--- a/javers-core/src/test/groovy/org/javers/core/cases/KeyValueTypeParameterResolutionTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/cases/KeyValueTypeParameterResolutionTest.groovy
@@ -1,0 +1,250 @@
+package org.javers.core.cases
+
+import org.javers.core.JaversBuilder
+import org.javers.core.metamodel.type.KeyValueType
+import spock.lang.Specification
+
+/**
+ * https://github.com/javers/javers/issues/1450
+ *
+ * These tests use {@link java.util.Map}, but they should apply to any types that
+ * are handled by {@link org.javers.core.metamodel.type.KeyValueType},
+ * since they all have type parameters {@code <K, V>}.
+ *
+ * @author Yat Ho
+ */
+class KeyValueTypeParameterResolutionTest extends Specification {
+    class ExtendsMapSubtype extends HashMap<String, Integer> {}
+
+    def "should recognise key and value types from Map subclass"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<KeyValueType> getTypeMapping(ExtendsMapSubtype)
+        def expectedJType = javers.<KeyValueType> getTypeMapping(ExtendsMapSubtype.getGenericSuperclass())
+
+        then:
+        jType.getKeyJavaType() == expectedJType.getKeyJavaType()
+        jType.getValueJavaType() == expectedJType.getValueJavaType()
+    }
+
+    class ImplementsMap implements Map<String, Integer> {
+        @Override
+        int size() {
+            return 0
+        }
+
+        @Override
+        boolean isEmpty() {
+            return true
+        }
+
+        @Override
+        boolean containsKey(Object key) {
+            return false
+        }
+
+        @Override
+        boolean containsValue(Object value) {
+            return false
+        }
+
+        @Override
+        Integer get(Object key) {
+            return null
+        }
+
+        @Override
+        Integer put(String key, Integer value) {
+            return null
+        }
+
+        @Override
+        Integer remove(Object key) {
+            return null
+        }
+
+        @Override
+        void putAll(Map<? extends String, ? extends Integer> m) {}
+
+        @Override
+        void clear() {}
+
+        @Override
+        Set<String> keySet() {
+            return null
+        }
+
+        @Override
+        Collection<Integer> values() {
+            return null
+        }
+
+        @Override
+        Set<Entry<String, Integer>> entrySet() {
+            return null
+        }
+    }
+
+    def "should recognise key and value types from Map interface"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<KeyValueType> getTypeMapping(ImplementsMap)
+        def expectedJType = javers.<KeyValueType> getTypeMapping(ImplementsMap.getGenericInterfaces()[0])
+
+        then:
+        jType.getKeyJavaType() == expectedJType.getKeyJavaType()
+        jType.getValueJavaType() == expectedJType.getValueJavaType()
+    }
+
+    interface ExtendsMap extends Map<String, Integer> {}
+
+    class ImplementsExtendsMap implements ExtendsMap {
+        @Override
+        int size() {
+            return 0
+        }
+
+        @Override
+        boolean isEmpty() {
+            return true
+        }
+
+        @Override
+        boolean containsKey(Object key) {
+            return false
+        }
+
+        @Override
+        boolean containsValue(Object value) {
+            return false
+        }
+
+        @Override
+        Integer get(Object key) {
+            return null
+        }
+
+        @Override
+        Integer put(String key, Integer value) {
+            return null
+        }
+
+        @Override
+        Integer remove(Object key) {
+            return null
+        }
+
+        @Override
+        void putAll(Map<? extends String, ? extends Integer> m) {}
+
+        @Override
+        void clear() {}
+
+        @Override
+        Set<String> keySet() {
+            return null
+        }
+
+        @Override
+        Collection<Integer> values() {
+            return null
+        }
+
+        @Override
+        Set<Entry<String, Integer>> entrySet() {
+            return null
+        }
+    }
+
+    def "should recognise key and value types from Map subinterface"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<KeyValueType> getTypeMapping(ImplementsExtendsMap)
+        def expectedJType = javers.<KeyValueType> getTypeMapping(ImplementsExtendsMap.getInterfaces()[0].getGenericInterfaces()[0])
+
+        then:
+        jType.getKeyJavaType() == expectedJType.getKeyJavaType()
+        jType.getValueJavaType() == expectedJType.getValueJavaType()
+    }
+
+    class EmptyClass {}
+
+    class ExtendsEmptyClass extends EmptyClass {}
+
+    class ExtendsImplementsMapInMiddle extends ExtendsEmptyClass implements Map<String, Integer> {
+        @Override
+        int size() {
+            return 0
+        }
+
+        @Override
+        boolean isEmpty() {
+            return true
+        }
+
+        @Override
+        boolean containsKey(Object key) {
+            return false
+        }
+
+        @Override
+        boolean containsValue(Object value) {
+            return false
+        }
+
+        @Override
+        Integer get(Object key) {
+            return null
+        }
+
+        @Override
+        Integer put(String key, Integer value) {
+            return null
+        }
+
+        @Override
+        Integer remove(Object key) {
+            return null
+        }
+
+        @Override
+        void putAll(Map<? extends String, ? extends Integer> m) {}
+
+        @Override
+        void clear() {}
+
+        @Override
+        Set<String> keySet() {
+            return null
+        }
+
+        @Override
+        Collection<Integer> values() {
+            return null
+        }
+
+        @Override
+        Set<Entry<String, Integer>> entrySet() {
+            return null
+        }
+    }
+
+    def "should recognise key and value types when Map is not the superest superinterface"() {
+        given:
+        def javers = JaversBuilder.javers().build()
+
+        when:
+        def jType = javers.<KeyValueType> getTypeMapping(ExtendsImplementsMapInMiddle)
+        def expectedJType = javers.<KeyValueType> getTypeMapping(ExtendsImplementsMapInMiddle.getGenericInterfaces()[0])
+
+        then:
+        jType.getKeyJavaType() == expectedJType.getKeyJavaType()
+        jType.getValueJavaType() == expectedJType.getValueJavaType()
+    }
+}


### PR DESCRIPTION
Fixes #1450

Improved type parameter resolution for enumerable types, e.g. `Collections<E>`, `Map<K, V>`.

More specifically, this PR adds the ability for Javers to determine key/value types of collections and maps even if the subclass does not have type parameters. Before this PR, Javers was only able to determine key/value types from the type parameters of the immediate subclass.

An example of such types:

```java
class StringIntMap extends HashMap<String, Integer> {}
```

Before this PR, Javer thinks the key/value types are `<Object, Object>`, now it can correctly recognise `<String, Integer>`.