### PR TITLE
 introduced terminal snapshots for removed Value Objects

### DIFF
--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -707,7 +707,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
      * generate additional set of Initial Changes for each
      * property of a NewObject to capture its state.
      * <br/>
-     * Internally, Javers generates Initial Changes by comparing a virtual, totally empty object
+     * Internally, Javers generates Initial Changes by comparing a virtual, empty object
      * with a real NewObject.
      *
      * <br/><br/>

--- a/javers-core/src/main/java/org/javers/core/commit/Commit.java
+++ b/javers-core/src/main/java/org/javers/core/commit/Commit.java
@@ -3,17 +3,13 @@ package org.javers.core.commit;
 import org.javers.common.validation.Validate;
 import org.javers.core.Changes;
 import org.javers.core.CommitIdGenerator;
-import org.javers.core.diff.Change;
 import org.javers.core.diff.Diff;
-import org.javers.core.graph.Cdo;
 import org.javers.core.metamodel.object.CdoSnapshot;
+import org.javers.core.metamodel.object.SnapshotType;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 
 /**
  * JaVers commit is a similar concept to GIT commit.
@@ -110,11 +106,33 @@ public final class Commit {
     public String toString() {
         StringBuilder b = new StringBuilder();
         b.append("Commit(id:" + commitMetadata.getId());
-        b.append(", snapshots:" + snapshots.size());
+        b.append(", " + snapshotSummary());
         b.append(", author:" + commitMetadata.getAuthor());
-        b.append(", " + diff.changesSummary());
         b.append(")");
         return b.toString();
+    }
+
+    private String snapshotSummary(){
+        StringBuilder b = new StringBuilder();
+
+        b.append("snapshots:" + snapshots.size()+" ");
+        for (Map.Entry<SnapshotType, Integer> e : countByType().entrySet()){
+            b.append(e.getKey() + ":"+e.getValue()+" ");
+        }
+        return b.toString().trim();
+    }
+
+    private Map<SnapshotType, Integer> countByType(){
+        Map<SnapshotType, Integer> result = new HashMap<>();
+        for(CdoSnapshot snapshot : snapshots) {
+            SnapshotType key = snapshot.getType();
+            if (result.containsKey(key)){
+                result.put(key, (result.get(key))+1);
+            }else{
+                result.put(key, 1);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
+++ b/javers-core/src/main/java/org/javers/core/commit/CommitFactory.java
@@ -2,8 +2,6 @@ package org.javers.core.commit;
 
 import org.javers.common.collections.Lists;
 import org.javers.common.date.DateProvider;
-import org.javers.common.exception.JaversException;
-import org.javers.common.exception.JaversExceptionCode;
 import org.javers.core.diff.Diff;
 import org.javers.core.diff.DiffFactory;
 import org.javers.core.graph.Cdo;
@@ -72,7 +70,7 @@ public class CommitFactory {
 
     private Commit createCommit(String author, Map<String, String> properties, LiveGraph currentGraph){
         CommitMetadata commitMetadata = newCommitMetadata(author, properties);
-        ObjectGraph<CdoSnapshot> latestSnapshotGraph = snapshotGraphFactory.createLatest(currentGraph.globalIds());
+        ObjectGraph<CdoSnapshot> latestSnapshotGraph = snapshotGraphFactory.loadLatestAndCreateGraph(currentGraph.globalIds());
         List<CdoSnapshot> changedCdoSnapshots =
             changedCdoSnapshotsFactory.create(currentGraph, latestSnapshotGraph.cdos(), commitMetadata);
         Diff diff = diffFactory.create(latestSnapshotGraph, currentGraph, Optional.of(commitMetadata));

--- a/javers-core/src/main/java/org/javers/core/diff/DiffFactory.java
+++ b/javers-core/src/main/java/org/javers/core/diff/DiffFactory.java
@@ -133,7 +133,7 @@ public class DiffFactory {
         }
 
         //calculate property-to-property diff
-        for (NodePair pair : nodeMatcher.match(graphPair)) {
+        for (NodePair pair : graphPair.getMatching()) {
             appendPropertyChanges(diff, pair);
         }
 

--- a/javers-core/src/main/java/org/javers/core/diff/GraphPair.java
+++ b/javers-core/src/main/java/org/javers/core/diff/GraphPair.java
@@ -22,7 +22,7 @@ public class GraphPair {
 
     private final Collection<ObjectNode> onlyOnLeft;
     private final Collection<ObjectNode> onlyOnRight;
-
+    private final Collection<NodePair> matching;
     private final Optional<CommitMetadata> commitMetadata;
 
     GraphPair(ObjectGraph leftGraph, ObjectGraph rightGraph) {
@@ -39,6 +39,7 @@ public class GraphPair {
         this.onlyOnRight = difference(rightGraph.nodes(), leftGraph.nodes(), hasher);
 
         this.commitMetadata = commitMetadata;
+        this.matching = NodeMatcher.match(leftGraph.nodes(), rightGraph.nodes(), commitMetadata);
     }
 
     //for initial
@@ -51,6 +52,12 @@ public class GraphPair {
         this.onlyOnRight = rightGraph.nodes();
 
         this.commitMetadata = Optional.empty();
+
+        this.matching = Collections.emptyList();
+    }
+
+    public Collection<NodePair> getMatching() {
+        return matching;
     }
 
     public Collection<ObjectNode> getOnlyOnLeft() {

--- a/javers-core/src/main/java/org/javers/core/diff/NodeMatcher.java
+++ b/javers-core/src/main/java/org/javers/core/diff/NodeMatcher.java
@@ -1,6 +1,7 @@
 package org.javers.core.diff;
 
 import org.javers.common.validation.Validate;
+import org.javers.core.commit.CommitMetadata;
 import org.javers.core.graph.ObjectNode;
 import org.javers.core.metamodel.object.GlobalId;
 import java.util.*;
@@ -12,23 +13,23 @@ class NodeMatcher {
     /**
      * matching based on {@link org.javers.core.metamodel.object.GlobalId}
      */
-    public List<NodePair> match(GraphPair graphPair) {
-        Validate.argumentIsNotNull(graphPair);
+    static List<NodePair> match(Set<ObjectNode> leftNodes, Set<ObjectNode> rightNodes, Optional<CommitMetadata> commitMetadata) {
+        Validate.argumentsAreNotNull(leftNodes, rightNodes, commitMetadata);
 
         List<NodePair> pairs = new ArrayList<>();
-        Map<GlobalId, ObjectNode> rightMap = asMap(graphPair.getRightNodeSet());
+        Map<GlobalId, ObjectNode> rightMap = asMap(rightNodes);
 
-        for (ObjectNode left : graphPair.getLeftNodeSet()) {
+        for (ObjectNode left : leftNodes) {
             GlobalId key = left.getGlobalId();
             if (rightMap.containsKey(key)) {
-                pairs.add(new NodePair(left, rightMap.get(key), graphPair.getCommitMetadata()));
+                pairs.add(new NodePair(left, rightMap.get(key), commitMetadata));
             }
         }
 
         return pairs;
     }
 
-    private Map<GlobalId, ObjectNode> asMap(Set<ObjectNode> nodes) {
+    private static Map<GlobalId, ObjectNode> asMap(Set<ObjectNode> nodes) {
         Map<GlobalId, ObjectNode> map = new HashMap<>();
 
         for (ObjectNode node : nodes) {

--- a/javers-core/src/main/java/org/javers/core/metamodel/object/CdoSnapshot.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/object/CdoSnapshot.java
@@ -6,6 +6,7 @@ import org.javers.core.commit.CommitMetadata;
 import org.javers.core.graph.Cdo;
 import org.javers.core.metamodel.property.Property;
 import org.javers.core.metamodel.type.ManagedType;
+import org.javers.core.metamodel.type.ValueObjectType;
 
 import java.util.List;
 import java.util.Optional;
@@ -194,5 +195,13 @@ public final class CdoSnapshot extends Cdo {
         getManagedType().getProperties().forEach( p ->
                 builder.withPropertyValue(p, getPropertyValue(p)));
         return builder.build();
+    }
+
+    public boolean isValueObject() {
+        return getManagedType() instanceof ValueObjectType;
+    }
+
+    public boolean isTerminalVO() {
+        return isValueObject() && isTerminal();
     }
 }

--- a/javers-core/src/main/java/org/javers/core/snapshot/SnapshotDiffer.java
+++ b/javers-core/src/main/java/org/javers/core/snapshot/SnapshotDiffer.java
@@ -57,7 +57,10 @@ public class SnapshotDiffer {
     }
 
     private void addTerminalChanges(List<Change> changes, CdoSnapshot terminalSnapshot, CdoSnapshot previousSnapshot) {
-        changes.add(new ObjectRemoved(terminalSnapshot.getGlobalId(), empty(), of(terminalSnapshot.getCommitMetadata())));
+        if (! (terminalSnapshot.isValueObject())){
+            changes.add(new ObjectRemoved(terminalSnapshot.getGlobalId(), empty(), of(terminalSnapshot.getCommitMetadata())));
+        }
+
         if (previousSnapshot != null && javersCoreConfiguration.isTerminalChanges()) {
             Diff terminalDiff = diffFactory.create(snapshotGraph(previousSnapshot), snapshotGraph(terminalSnapshot), commitMetadata(terminalSnapshot));
             changes.addAll(terminalDiff.getChanges());

--- a/javers-core/src/main/java/org/javers/core/snapshot/SnapshotGraphFactory.java
+++ b/javers-core/src/main/java/org/javers/core/snapshot/SnapshotGraphFactory.java
@@ -1,7 +1,6 @@
 package org.javers.core.snapshot;
 
 import org.javers.common.validation.Validate;
-import org.javers.core.graph.ObjectNode;
 import org.javers.core.metamodel.object.CdoSnapshot;
 import org.javers.core.metamodel.object.GlobalId;
 import org.javers.repository.api.JaversExtendedRepository;
@@ -19,7 +18,15 @@ public class SnapshotGraphFactory {
         this.javersRepository = javersRepository;
     }
 
-    public SnapshotGraph createLatest(Set<GlobalId> globalIds){
+    public List<CdoSnapshot> loadLatest(Collection<GlobalId> globalIds) {
+        Validate.argumentIsNotNull(globalIds);
+
+        return javersRepository.getLatest(globalIds)
+                .stream()
+                .collect(Collectors.toList());
+    }
+
+    public SnapshotGraph loadLatestAndCreateGraph(Set<GlobalId> globalIds){
         Validate.argumentIsNotNull(globalIds);
 
         Set<SnapshotNode> snapshotNodes = javersRepository.getLatest(globalIds)

--- a/javers-core/src/main/java/org/javers/repository/jql/ShadowQueryRunner.java
+++ b/javers-core/src/main/java/org/javers/repository/jql/ShadowQueryRunner.java
@@ -73,7 +73,10 @@ class ShadowQueryRunner {
     }
 
     private List<CdoSnapshot> queryForCoreSnapshots(JqlQuery query, ShadowStats queryStats) {
-        List<CdoSnapshot> snapshots = snapshotQueryRunner.queryForSnapshots(query);
+        List<CdoSnapshot> snapshots = snapshotQueryRunner.queryForSnapshots(query)
+                .stream()
+                .filter(s -> !s.isTerminalVO())
+                .collect(toList());
         queryStats.logShallowQuery(snapshots);
 
         return snapshots;

--- a/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversCommitE2ETest.groovy
@@ -239,7 +239,7 @@ class JaversCommitE2ETest extends Specification {
                     .hasValueChangeAt("city", null, "Tokyo")
     }
 
-    def "should not record ObjectRemoved for removed ValueObject"() {
+    def "should record terminal snapshots for removed ValueObject"() {
         given:
         def javers = javers().build()
         def user = dummyUser().withDetails(5).withAddress("Tokyo")
@@ -250,10 +250,10 @@ class JaversCommitE2ETest extends Specification {
         def commit = javers.commit("some.login", user)
 
         then:
-        def voId = valueObjectId(5, DummyUserDetails, "dummyAddress")
         CommitAssert.assertThat(commit)
-                    .hasSnapshots(1)
+                    .hasSnapshots(2)
                     .hasSnapshot(instanceId(5, DummyUserDetails))
+                    .hasTerminalSnapshot(valueObjectId(5, DummyUserDetails, "dummyAddress"))
                     .hasChanges(0)
     }
 

--- a/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversDiffE2ETest.groovy
@@ -24,6 +24,7 @@ import org.javers.core.metamodel.type.ManagedType
 import org.javers.core.metamodel.type.SetType
 import org.javers.core.metamodel.type.ValueObjectType
 import org.javers.core.model.*
+import org.javers.repository.jql.QueryBuilder
 import spock.lang.Unroll
 
 import jakarta.persistence.EmbeddedId
@@ -888,5 +889,23 @@ class JaversDiffE2ETest extends AbstractDiffTest {
 
         then:
         changes.size() == 0
+    }
+
+    def "should calculate changes for removed ValueObject"() {
+        given:
+        def javers = javers().build()
+        def s1 = new SnapshotEntity(id:1, valueObjectRef: new DummyAddress(city:"London"))
+        def s2 = new SnapshotEntity(id:1)
+
+        when:
+        def diff = javers.compare(s1, s2)
+        println diff.prettyPrint()
+
+        then:
+        diff.changes.size() == 1
+        def change = diff.changes[0]
+        change instanceof ValueChange
+        change.left == "London"
+        change.right == null
     }
 }

--- a/javers-core/src/test/groovy/org/javers/core/diff/NodeMatcherTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/diff/NodeMatcherTest.groovy
@@ -14,7 +14,7 @@ class NodeMatcherTest extends AbstractDiffTest{
         def currentGraph =   buildLiveGraph(dummyUser("b").withDetails(2))
 
         when:
-        def pairs = new NodeMatcher().match(new GraphPair(previousGraph,currentGraph))
+        def pairs = new NodeMatcher().match(previousGraph.nodes(),currentGraph.nodes(), Optional.empty())
 
         then:
         pairs.size() == 1

--- a/javers-core/src/test/groovy/org/javers/core/examples/JqlExample.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/examples/JqlExample.groovy
@@ -352,10 +352,11 @@ class JqlExample extends Specification {
 
         when:
         Changes changes = javers.findChanges( QueryBuilder.byClass(DummyAddress.class).build() )
+        print changes.prettyPrint()
 
         then:
         println changes.prettyPrint()
-        assert changes.size() == 4
+        assert changes.size() == 5
     }
 
     def "should query for any domain object changes"() {

--- a/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotGraphFactoryTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/snapshot/SnapshotGraphFactoryTest.groovy
@@ -29,7 +29,7 @@ class SnapshotGraphFactoryTest extends Specification {
         def liveGraph = javers.createLiveGraph(cdo)
 
         when:
-        def snapshotGraph = snapshotGraphFactory.createLatest(liveGraph.globalIds())
+        def snapshotGraph = snapshotGraphFactory.loadLatestAndCreateGraph(liveGraph.globalIds())
 
         then:
         snapshotGraph.nodes().size() == 1


### PR DESCRIPTION
Fix for https://github.com/javers/javers/issues/1372

Value changes for removed Value Objects are now recorded in the queryForChanges