### PR TITLE
change MongoRepositoryConfiguration to public

### DIFF
--- a/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepositoryConfiguration.java
+++ b/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepositoryConfiguration.java
@@ -5,7 +5,7 @@ import org.javers.repository.mongo.model.MongoHeadId;
 
 import static org.javers.repository.mongo.MongoDialect.MONGO_DB;
 
-class MongoRepositoryConfiguration {
+public class MongoRepositoryConfiguration {
     private static final String DEFAULT_SNAPSHOT_COLLECTION_NAME = "jv_snapshots";
 
     private static final String DEFAULT_HEAD_COLLECTION_NAME = "jv_head_id";


### PR DESCRIPTION
Allows library users on Kotlin 2.3 to use this class explicitly.

Relevant Kotlin warning: `Inferred return type 'MongoRepositoryConfiguration!' for 'build' is not visible in this scope. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-25513.`