### PR TITLE
#1373 fix for withChildValueObjects() if @id has java.util.UUID type when using MongoRepository

### DIFF
--- a/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepository.java
+++ b/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepository.java
@@ -185,9 +185,14 @@ public class MongoRepository implements JaversRepository, ConfigurationAware {
 
     private Bson createIdQueryWithAggregate(GlobalId id) {
         if (id instanceof InstanceId) {
+            Object cdoId = ((InstanceId)id).getCdoId();
+            if (cdoId instanceof UUID) {
+                UUID uuidCdoId = (UUID) cdoId;
+                cdoId = uuidCdoId.toString();
+            }
             return Filters.or(
                 createIdQuery(id),
-                new BasicDBObject(GLOBAL_ID_OWNER_ID_CDO_ID, ((InstanceId)id).getCdoId())
+                new BasicDBObject(GLOBAL_ID_OWNER_ID_CDO_ID, cdoId)
             );
         }
 

--- a/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepository.java
+++ b/javers-persistence-mongo/src/main/java/org/javers/repository/mongo/MongoRepository.java
@@ -185,14 +185,9 @@ public class MongoRepository implements JaversRepository, ConfigurationAware {
 
     private Bson createIdQueryWithAggregate(GlobalId id) {
         if (id instanceof InstanceId) {
-            Object cdoId = ((InstanceId)id).getCdoId();
-            if (cdoId instanceof UUID) {
-                UUID uuidCdoId = (UUID) cdoId;
-                cdoId = uuidCdoId.toString();
-            }
             return Filters.or(
                 createIdQuery(id),
-                new BasicDBObject(GLOBAL_ID_OWNER_ID_CDO_ID, cdoId)
+                new BasicDBObject(GLOBAL_ID_OWNER_ID_CDO_ID, ((InstanceId)id).getCdoId().toString())
             );
         }
 

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/DockerizedMongoContainer.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/DockerizedMongoContainer.groovy
@@ -1,5 +1,7 @@
 package org.javers.repository.mongo
 
+import com.mongodb.ConnectionString
+import com.mongodb.MongoClientSettings
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import org.testcontainers.mongodb.MongoDBContainer
@@ -11,6 +13,13 @@ class DockerizedMongoContainer {
     DockerizedMongoContainer() {
         this.mongoDBContainer = startMongo()
         this.mongoClient = MongoClients.create(mongoDBContainer.replicaSetUrl)
+    }
+
+    DockerizedMongoContainer(MongoClientSettings.Builder mongoClientSettingsBuilder) {
+        this.mongoDBContainer = startMongo()
+        this.mongoClient = MongoClients.create(
+                mongoClientSettingsBuilder
+                        .applyConnectionString(new ConnectionString(mongoDBContainer.replicaSetUrl)).build())
     }
 
     MongoDBContainer startMongo() {

--- a/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/MongoE2EWithChildValueObjectsLookupByUuidTest.groovy
+++ b/javers-persistence-mongo/src/test/groovy/org/javers/repository/mongo/MongoE2EWithChildValueObjectsLookupByUuidTest.groovy
@@ -1,0 +1,67 @@
+package org.javers.repository.mongo
+
+import com.mongodb.MongoClientSettings
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoDatabase
+import jakarta.persistence.Id
+import org.bson.UuidRepresentation
+import org.testcontainers.spock.Testcontainers
+import spock.lang.Shared
+
+import static org.javers.repository.jql.QueryBuilder.byInstance
+
+@Testcontainers
+class MongoE2EWithChildValueObjectsLookupByUuidTest extends JaversMongoRepositoryE2ETest {
+
+    @Shared
+    static DockerizedMongoContainer dockerizedMongoContainer = new DockerizedMongoContainer(MongoClientSettings
+            .builder()
+            .uuidRepresentation(UuidRepresentation.STANDARD))
+
+    @Shared
+    static MongoClient mongoClient = dockerizedMongoContainer.mongoClient
+
+    @Override
+    protected MongoDatabase getMongoDb() {
+        mongoClient.getDatabase("test")
+    }
+
+    class Parent {
+        @Id
+        UUID id;
+        List<Child> children;
+    }
+
+    class Child {
+        List<GrandChild> grandChildren;
+    }
+
+    class GrandChild {
+        String value;
+    }
+
+    def "withChildValueObjects() should work with UUID as entity id"() {
+        given:
+        GrandChild grandChild1 = new GrandChild(value: "value1")
+        GrandChild grandChild2 = new GrandChild(value: "value2")
+        GrandChild grandChild3 = new GrandChild(value: "value3")
+        GrandChild grandChild4 = new GrandChild(value: "value4")
+        GrandChild grandChild5 = new GrandChild(value: "value5")
+        GrandChild grandChild6 = new GrandChild(value: "value6")
+
+        Child child1 = new Child(grandChildren: [grandChild1, grandChild2])
+        Child child2 = new Child(grandChildren: [grandChild3, grandChild4, grandChild5])
+        Child child3 = new Child(grandChildren: [grandChild6])
+
+        Parent parent = new Parent(id: UUID.randomUUID(), children: [child1, child2, child3])
+
+        javers.commit("author", parent)
+
+        when:
+        def query = byInstance(parent).withChildValueObjects().build()
+        def snapshots = javers.findSnapshots(query)
+
+        then:
+        assert snapshots.size() == 10 // 1x Parent, 3x Child, 6x GrandChild
+    }
+}


### PR DESCRIPTION
This MR adds a check to `MongoRepository` so that if 'UUID' id types are converted to a `String` when building a query with the cdo id.  This is as the id is stored as a String in `globalId.ownerId.cdoId`, but passing the UUID id object into the Mongo query builder will query for a UUID type.

I've added the E2E test that was documented in the issue in a separate branch to demonstrate the issue before this fix.  This is on this branch https://github.com/javers/javers/compare/master...jarebudev:javers:1373_demonstrate_uuid_error

Fixes #1373 