### PR TITLE
#1488 add property to control pro banner print

### DIFF
--- a/javers-core/src/main/java/org/javers/core/JaversBuilder.java
+++ b/javers-core/src/main/java/org/javers/core/JaversBuilder.java
@@ -99,6 +99,7 @@ public class JaversBuilder extends AbstractContainerBuilder {
     private JaversRepository repository;
     private DateProvider dateProvider;
     private long bootStart = System.currentTimeMillis();
+    private boolean printProBanner = true;
     private Class<? extends ObjectHasher> objectHasherImplementation = SnapshotObjectHasher.class;
 
     private IgnoredClassesStrategy ignoredClassesStrategy;
@@ -133,7 +134,9 @@ public class JaversBuilder extends AbstractContainerBuilder {
         Javers javers = assembleJaversInstanceAndEnsureSchema();
 
         long boot = System.currentTimeMillis() - bootStart;
-        printProBanner();
+        if (printProBanner) {
+            printProBanner();
+        }
         logger.info("JaVers instance started in {} ms", boot);
         return javers;
     }
@@ -936,8 +939,16 @@ public class JaversBuilder extends AbstractContainerBuilder {
         if (javersProperties.isUsePrimitiveDefaults() != null) {
             withUsePrimitiveDefaults(javersProperties.isUsePrimitiveDefaults());
         }
+        if (javersProperties.isPrintProBanner() != null) {
+            withPrintProBanner(javersProperties.isPrintProBanner());
+        }
 
         withPrettyPrintDateFormats(javersProperties.getPrettyPrintDateFormats());
+        return this;
+    }
+
+    public JaversBuilder withPrintProBanner(boolean printProBanner) {
+        this.printProBanner = printProBanner;
         return this;
     }
 

--- a/javers-core/src/main/java/org/javers/core/JaversCoreProperties.java
+++ b/javers-core/src/main/java/org/javers/core/JaversCoreProperties.java
@@ -20,6 +20,7 @@ public abstract class JaversCoreProperties {
     private String packagesToScan = "";
     private PrettyPrintDateFormats prettyPrintDateFormats = new PrettyPrintDateFormats();
     private Boolean usePrimitiveDefaults;
+    private Boolean printProBanner;
 
     public String getAlgorithm() {
         return algorithm;
@@ -71,6 +72,14 @@ public abstract class JaversCoreProperties {
 
     public Boolean isTypeSafeValues() {
         return typeSafeValues;
+    }
+
+    public Boolean isPrintProBanner() {
+        return printProBanner;
+    }
+
+    public void setPrintProBanner(Boolean printProBanner) {
+        this.printProBanner = printProBanner;
     }
 
     public String getPackagesToScan() {

--- a/javers-core/src/test/groovy/org/javers/core/JaversBuilderProBannerTest.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/JaversBuilderProBannerTest.groovy
@@ -1,0 +1,78 @@
+package org.javers.core
+
+import spock.lang.Specification
+
+/**
+ * @see <a href="https://github.com/javers/javers/issues/1488">#1488</a>
+ */
+class JaversBuilderProBannerTest extends Specification {
+
+    private static final String BANNER_MARKER = "JaVers is Evolving to Open Core!"
+
+    private PrintStream originalOut
+    private ByteArrayOutputStream captured
+
+    def setup() {
+        // the banner is printed at most once per JVM, so the guard has to be
+        // cleared or an earlier build() in the suite would mask the assertion
+        resetProBannerPrintedFlag()
+        originalOut = System.out
+        captured = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(captured))
+    }
+
+    def cleanup() {
+        System.setOut(originalOut)
+        resetProBannerPrintedFlag()
+    }
+
+    def "should print pro banner by default"() {
+        when:
+        JaversBuilder.javers().build()
+
+        then:
+        capturedOut().contains(BANNER_MARKER)
+    }
+
+    def "should not print pro banner when disabled in JaversBuilder"() {
+        when:
+        JaversBuilder.javers().withPrintProBanner(false).build()
+
+        then:
+        !capturedOut().contains(BANNER_MARKER)
+    }
+
+    def "should not print pro banner when disabled in JaversCoreProperties"() {
+        given:
+        def properties = new JaversCoreProperties() {}
+        properties.setPrintProBanner(false)
+
+        when:
+        JaversBuilder.javers().withProperties(properties).build()
+
+        then:
+        !capturedOut().contains(BANNER_MARKER)
+    }
+
+    def "should print pro banner when JaversCoreProperties leaves it unset"() {
+        given:
+        def properties = new JaversCoreProperties() {}
+
+        when:
+        JaversBuilder.javers().withProperties(properties).build()
+
+        then:
+        capturedOut().contains(BANNER_MARKER)
+    }
+
+    private String capturedOut() {
+        System.out.flush()
+        captured.toString()
+    }
+
+    private static void resetProBannerPrintedFlag() {
+        def field = JaversBuilder.getDeclaredField("proBannerPrinted")
+        field.setAccessible(true)
+        field.setBoolean(null, false)
+    }
+}


### PR DESCRIPTION
Closes #1488.

Supersedes #1489, which was closed unmerged. Same approach as @nstdio's original, with both review comments from that PR applied:

1. `printProBanner` defaults to `true`, so existing behaviour is unchanged — the banner keeps printing for everyone who doesn't explicitly opt out.
2. The switch is wired through `JaversCoreProperties`, so it can be set from `application.yml` in the Spring Boot starter. `JaversSpringProperties` already extends `JaversCoreProperties`, so no Spring-side changes were needed.

We appreciate the continuous effort put into this library but would kindly request a way to disable the banner.