### PR TITLE
#1076 convert MissingProperty to null before CustomPropertyComparator

### DIFF
--- a/javers-core/src/main/java/org/javers/core/diff/changetype/Atomic.java
+++ b/javers-core/src/main/java/org/javers/core/diff/changetype/Atomic.java
@@ -42,7 +42,7 @@ public class Atomic implements Serializable {
      * original Value
      */
     public Object unwrap() {
-        return MissingProperty.INSTANCE == value ? null : value;
+        return MissingProperty.unwrap(value);
     }
 
     @Override

--- a/javers-core/src/main/java/org/javers/core/diff/custom/CustomToNativeAppenderAdapter.java
+++ b/javers-core/src/main/java/org/javers/core/diff/custom/CustomToNativeAppenderAdapter.java
@@ -3,6 +3,7 @@ package org.javers.core.diff.custom;
 import org.javers.core.diff.NodePair;
 import org.javers.core.diff.appenders.PropertyChangeAppender;
 import org.javers.core.diff.changetype.PropertyChange;
+import org.javers.core.metamodel.property.MissingProperty;
 import org.javers.core.metamodel.type.JaversProperty;
 import org.javers.core.metamodel.type.JaversType;
 
@@ -25,10 +26,22 @@ public class CustomToNativeAppenderAdapter<T, C extends PropertyChange> implemen
 
     @Override
     public C calculateChanges(NodePair pair, JaversProperty property) {
-        T leftValue = (T)pair.getLeftPropertyValue(property);
-        T rightValue = (T)pair.getRightPropertyValue(property);
+        T leftValue = sanitizeMissingProperty(pair.getLeftPropertyValue(property));
+        T rightValue = sanitizeMissingProperty(pair.getRightPropertyValue(property));
 
         return delegate.compare(leftValue, rightValue, pair.createPropertyChangeMetadata(property), property).orElse(null);
+    }
+
+    /**
+     * {@link MissingProperty} is an internal marker for "property present on only one side".
+     * It must not leak into user {@link CustomPropertyComparator} implementations (see #1076).
+     */
+    @SuppressWarnings("unchecked")
+    private T sanitizeMissingProperty(Object value) {
+        if (value == MissingProperty.INSTANCE) {
+            return null;
+        }
+        return (T) value;
     }
 
     @Override

--- a/javers-core/src/main/java/org/javers/core/diff/custom/CustomToNativeAppenderAdapter.java
+++ b/javers-core/src/main/java/org/javers/core/diff/custom/CustomToNativeAppenderAdapter.java
@@ -26,22 +26,10 @@ public class CustomToNativeAppenderAdapter<T, C extends PropertyChange> implemen
 
     @Override
     public C calculateChanges(NodePair pair, JaversProperty property) {
-        T leftValue = sanitizeMissingProperty(pair.getLeftPropertyValue(property));
-        T rightValue = sanitizeMissingProperty(pair.getRightPropertyValue(property));
+        T leftValue = MissingProperty.unwrap(pair.getLeftPropertyValue(property));
+        T rightValue = MissingProperty.unwrap(pair.getRightPropertyValue(property));
 
         return delegate.compare(leftValue, rightValue, pair.createPropertyChangeMetadata(property), property).orElse(null);
-    }
-
-    /**
-     * {@link MissingProperty} is an internal marker for "property present on only one side".
-     * It must not leak into user {@link CustomPropertyComparator} implementations (see #1076).
-     */
-    @SuppressWarnings("unchecked")
-    private T sanitizeMissingProperty(Object value) {
-        if (value == MissingProperty.INSTANCE) {
-            return null;
-        }
-        return (T) value;
     }
 
     @Override

--- a/javers-core/src/main/java/org/javers/core/metamodel/property/MissingProperty.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/property/MissingProperty.java
@@ -1,9 +1,25 @@
 package org.javers.core.metamodel.property;
 
+/**
+ * Internal marker for a property present on only one side of a comparison.
+ * Must not leak into user comparators (see #1076).
+ */
 public class MissingProperty {
     public static final MissingProperty INSTANCE = new MissingProperty();
 
     private MissingProperty() {
+    }
+
+    /**
+     * Converts {@link #INSTANCE} to {@code null}; other values pass through.
+     * Aligns with {@link org.javers.core.diff.changetype.Atomic#unwrap()}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T unwrap(Object value) {
+        if (value == INSTANCE) {
+            return null;
+        }
+        return (T) value;
     }
 
     @Override

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/CustomType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/CustomType.java
@@ -72,15 +72,7 @@ public class CustomType<T> extends ClassType implements CustomComparableType {
 
         @Override
         public Optional<C> compare(T left, T right, PropertyChangeMetadata metadata, Property property) {
-            return delegate.compare(sanitizeMissingProperty(left), sanitizeMissingProperty(right), metadata, property);
-        }
-
-        @SuppressWarnings("unchecked")
-        private T sanitizeMissingProperty(Object value) {
-            if (value == MissingProperty.INSTANCE) {
-                return null;
-            }
-            return (T) value;
+            return delegate.compare(MissingProperty.unwrap(left), MissingProperty.unwrap(right), metadata, property);
         }
     }
 }

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/CustomType.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/CustomType.java
@@ -5,6 +5,7 @@ import org.javers.core.JaversBuilder;
 import org.javers.core.diff.changetype.PropertyChange;
 import org.javers.core.diff.changetype.PropertyChangeMetadata;
 import org.javers.core.diff.custom.CustomPropertyComparator;
+import org.javers.core.metamodel.property.MissingProperty;
 import org.javers.core.metamodel.property.Property;
 
 import java.lang.reflect.Type;
@@ -71,7 +72,15 @@ public class CustomType<T> extends ClassType implements CustomComparableType {
 
         @Override
         public Optional<C> compare(T left, T right, PropertyChangeMetadata metadata, Property property) {
-            return delegate.compare(left, right, metadata, property);
+            return delegate.compare(sanitizeMissingProperty(left), sanitizeMissingProperty(right), metadata, property);
+        }
+
+        @SuppressWarnings("unchecked")
+        private T sanitizeMissingProperty(Object value) {
+            if (value == MissingProperty.INSTANCE) {
+                return null;
+            }
+            return (T) value;
         }
     }
 }

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/CustomValueComparatorNullSafe.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/CustomValueComparatorNullSafe.java
@@ -31,7 +31,7 @@ class CustomValueComparatorNullSafe<T> implements CustomValueComparator<T> {
 
     @Override
     public String toString(T value) {
-        if (value == null) {
+        if (value == null || value == MissingProperty.INSTANCE) {
             return "";
         }
         return delegate.toString(value);

--- a/javers-core/src/main/java/org/javers/core/metamodel/type/CustomValueComparatorNullSafe.java
+++ b/javers-core/src/main/java/org/javers/core/metamodel/type/CustomValueComparatorNullSafe.java
@@ -31,9 +31,10 @@ class CustomValueComparatorNullSafe<T> implements CustomValueComparator<T> {
 
     @Override
     public String toString(T value) {
-        if (value == null || value == MissingProperty.INSTANCE) {
+        T sanitized = MissingProperty.unwrap(value);
+        if (sanitized == null) {
             return "";
         }
-        return delegate.toString(value);
+        return delegate.toString(sanitized);
     }
 }

--- a/javers-core/src/test/groovy/org/javers/core/cases/Case1076CustomPropertyComparatorMissingProperty.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/cases/Case1076CustomPropertyComparatorMissingProperty.groovy
@@ -1,0 +1,108 @@
+package org.javers.core.cases
+
+import org.javers.core.JaversBuilder
+import org.javers.core.diff.changetype.PropertyChangeMetadata
+import org.javers.core.diff.changetype.ValueChange
+import org.javers.core.diff.custom.CustomPropertyComparator
+import org.javers.core.metamodel.clazz.EntityDefinition
+import org.javers.core.metamodel.property.Property
+import spock.lang.Specification
+
+/**
+ * https://github.com/javers/javers/issues/1076
+ *
+ * MissingProperty must not be cast/passed into CustomPropertyComparator as T.
+ */
+class Case1076CustomPropertyComparatorMissingProperty extends Specification {
+
+    static class Container {
+        int id
+        Parent parent
+
+        Container(int id, Parent parent) {
+            this.id = id
+            this.parent = parent
+        }
+    }
+
+    static class Parent {}
+
+    static class ChildWithText extends Parent {
+        String text
+
+        ChildWithText(String text) {
+            this.text = text
+        }
+    }
+
+    static class ChildWithoutText extends Parent {}
+
+    /**
+     * Intentionally assumes both args are String or null (never MissingProperty).
+     * A ClassCastException from MissingProperty proves the bug.
+     */
+    static class NullSafeStringComparator implements CustomPropertyComparator<String, ValueChange> {
+        @Override
+        Optional<ValueChange> compare(String left, String right, PropertyChangeMetadata metadata, Property property) {
+            if (equals(left, right)) {
+                return Optional.empty()
+            }
+            return Optional.of(new ValueChange(metadata, left, right))
+        }
+
+        @Override
+        boolean equals(String a, String b) {
+            Objects.equals(normalize(a), normalize(b))
+        }
+
+        @Override
+        String toString(String value) {
+            return normalize(value)
+        }
+
+        private static String normalize(String s) {
+            return s == null ? "" : s
+        }
+    }
+
+    def "should not pass MissingProperty into CustomPropertyComparator when a property exists on only one side"() {
+        given:
+        def javers = JaversBuilder.javers()
+                .registerEntity(new EntityDefinition(Container.class, "id"))
+                .registerCustomType(String, new NullSafeStringComparator())
+                .build()
+
+        def left = new Container(1, new ChildWithText("hello"))
+        def right = new Container(1, new ChildWithoutText())
+
+        when:
+        def diff = javers.compare(left, right)
+
+        then:
+        noExceptionThrown()
+        diff.changes.size() >= 1
+    }
+
+    def "should treat MissingProperty as null for CustomPropertyComparator (null vs value is a change)"() {
+        given:
+        def javers = JaversBuilder.javers()
+                .registerEntity(new EntityDefinition(Container.class, "id"))
+                .registerCustomType(String, new NullSafeStringComparator())
+                .build()
+
+        def left = new Container(1, new ChildWithText("hello"))
+        def right = new Container(1, new ChildWithoutText())
+
+        when:
+        def diff = javers.compare(left, right)
+
+        then:
+        def textChanges = diff.changes.findAll {
+            it instanceof ValueChange && it.propertyName == "text"
+        }
+        textChanges.size() == 1
+        def change = textChanges[0] as ValueChange
+        change.left == "hello"
+        change.right == null
+    }
+}

--- a/javers-core/src/test/groovy/org/javers/core/cases/Case1076CustomPropertyComparatorMissingProperty.groovy
+++ b/javers-core/src/test/groovy/org/javers/core/cases/Case1076CustomPropertyComparatorMissingProperty.groovy
@@ -4,8 +4,11 @@ import org.javers.core.JaversBuilder
 import org.javers.core.diff.changetype.PropertyChangeMetadata
 import org.javers.core.diff.changetype.ValueChange
 import org.javers.core.diff.custom.CustomPropertyComparator
+import org.javers.core.diff.custom.CustomValueComparator
 import org.javers.core.metamodel.clazz.EntityDefinition
+import org.javers.core.metamodel.property.MissingProperty
 import org.javers.core.metamodel.property.Property
+import org.javers.core.metamodel.type.CustomComparableType
 import spock.lang.Specification
 
 /**
@@ -65,6 +68,21 @@ class Case1076CustomPropertyComparatorMissingProperty extends Specification {
         }
     }
 
+    /**
+     * Fails hard if MissingProperty leaks into toString (ClassCastException / wrong type).
+     */
+    static class StrictStringValueComparator implements CustomValueComparator<String> {
+        @Override
+        boolean equals(String a, String b) {
+            Objects.equals(a, b)
+        }
+
+        @Override
+        String toString(String value) {
+            return value.toUpperCase()
+        }
+    }
+
     def "should not pass MissingProperty into CustomPropertyComparator when a property exists on only one side"() {
         given:
         def javers = JaversBuilder.javers()
@@ -104,5 +122,18 @@ class Case1076CustomPropertyComparatorMissingProperty extends Specification {
         def change = textChanges[0] as ValueChange
         change.left == "hello"
         change.right == null
+    }
+
+    def "should not pass MissingProperty into CustomValueComparator.toString()"() {
+        given:
+        def javers = JaversBuilder.javers()
+                .registerValue(String, new StrictStringValueComparator())
+                .build()
+        def stringType = javers.getTypeMapping(String) as CustomComparableType
+
+        expect:
+        stringType.valueToString(MissingProperty.INSTANCE) == ""
+        stringType.valueToString(null) == ""
+        stringType.valueToString("ab") == "AB"
     }
 }


### PR DESCRIPTION
## Summary
- Convert internal `MissingProperty` to `null` before invoking user `CustomPropertyComparator` implementations
- Prevents `ClassCastException` when a property exists on only one side of a polymorphic compare
- Aligns with `Atomic.unwrap()` treating `MissingProperty` as null
- Regression tests in `Case1076CustomPropertyComparatorMissingProperty`

Fixes #1076

## Test plan
- [x] `./gradlew :javers-core:test --tests org.javers.core.cases.Case1076CustomPropertyComparatorMissingProperty` (2/2)
- [x] Related custom comparator suites (CustomPropertyComparatorE2ETest, cases, example) green
- [x] `./gradlew :javers-core:test` — 1504 tests green (Java 17)